### PR TITLE
Adding SSDP MSEARCH module

### DIFF
--- a/docs/modules/generic/upnp/ssdp_msearch.md
+++ b/docs/modules/generic/upnp/ssdp_msearch.md
@@ -1,0 +1,22 @@
+## Description
+
+Module sends M-SEARCH request to target and retrieve information from UPnP enabled systems.
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use generic/upnp/ssdp_msearch`
+  3. Do: `set target [TargetIP]`
+  4. Do: `run`
+  5. If target supports UPnP information are retrieved.
+
+## Scenarios
+
+```
+rsf > use generic/upnp/ssdp_msearch
+rsf (SSDP M-SEARCH Info Discovery) > set target 192.168.1.1
+[+] target => 192.168.1.1
+rsf (SSDP M-SEARCH Info Discovery) > run
+[*] Running module...
+[*] 192.168.1.1:1900 | Custom/1.0 UPnP/1.0 Proc/Ver | http://192.168.1.1:5431/dyndev/uuid:ec2280e5-e804-04e8-e580-22ec22e50400 | uuid:ec2280e5-e804-04e8-e580-22ec22e50400::upnp:rootdevice
+```

--- a/routersploit/modules/generic/upnp/ssdp_msearch.py
+++ b/routersploit/modules/generic/upnp/ssdp_msearch.py
@@ -1,0 +1,55 @@
+import re
+
+from routersploit.core.exploit import *
+from routersploit.core.udp.udp_client import UDPClient
+
+
+class Exploit(UDPClient):
+    __info__ = {
+        "name": "SSDP M-SEARCH Info Discovery",
+        "description": "Sends M-SEARCH request to target and retrieve information from UPnP "
+                       "enabled systems.",
+        "authors": (
+            "Marcin Bury <marcin[at]threat9.com>",  # routersploit module
+        ),
+        "references": (
+            "http://www.upnp-hacks.org/upnp.html",
+        ),
+    }
+
+    target = OptIP("", "Target IPv4 or IPv6")
+    port = OptPort(1900, "Target UPNP Port")
+
+    def run(self):
+        request = (
+            "M-SEARCH * HTTP/1.1\r\n" +
+            "HOST: {}:{}\r\n".format(self.target, self.port) +
+            "MAN: \"ssdp:discover\"\r\n" +
+            "MX: 2\r\n" +
+            "ST: upnp:rootdevice\r\n\r\n"
+        )
+
+        udp_client = self.udp_create()
+        self.udp_send(udp_client, request)
+
+        response = self.udp_recv(udp_client, 1024)
+        if response:
+            info = {}
+            regexps = {
+                "server": r"Server:\s*(.*?)\r\n",
+                "location": r"Location:\s*(.*?)\r\n",
+                "usn": r"USN:\s*(.*?)\r\n",
+            }
+
+            for key in regexps.keys():
+                res = re.findall(regexps[key], response, re.IGNORECASE)
+                if res:
+                    info[key] = res[0]
+                else:
+                    info[key] = ""
+
+            print_status("{}:{} | {} | {} | {}".format(self.target, self.port, info["server"], info["location"], info["usn"]))
+        else:
+            print_error("Target did not respond to M-SEARCH request")
+
+        self.udp_close(udp_client)


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds SSDP MSEARCH module that sends M-SEARCH request to the target and retrieve information from UPnP enabled systems.

## Verification
Provide steps to test or reproduce the PR.
  1. Start `./rsf.py`
  2. Do: `use generic/upnp/ssdp_msearch`
  3. Do: `set target [TargetIP]`
  4. Do: `run`
  5. If target supports UPnP information are retrieved.
