### PR TITLE
Fixed false positive issue #305 in version 3.1.0

### DIFF
--- a/routersploit/modules/exploits/routers/zte/zxv10_rce.py
+++ b/routersploit/modules/exploits/routers/zte/zxv10_rce.py
@@ -136,7 +136,8 @@ class Exploit(HTTPClient):
                     session=self.session,
                     data=data
                 )
-                if "Username" not in response.text and "Password" not in response.text:
+                if ("Username" not in response.text and "Password" not in response.text and
+                   "404 Not Found" not in response.text and response.status_code != 404):
                     print_success("Successful authentication")
                     return True
         except Exception:


### PR DESCRIPTION
Refixed issue after code reorganization

## Status
**READY**

## Description
Fixes again #305 after code was reorganized and the pull request #346's code that fixed it was deleted

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/zte/zxv10_rce`
 3. `set target 192.168.0.1`
 4. `run`

If the ZTE router returns a 404 status code and the exploit does not succeed, the message will be "Exploit failed" as it should be and not "Succesful authorization"

## Checklist
_Does not apply_
