### PR TITLE
setup.py improvements and routersploit/resources/ installation via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include routersploit/resources/ssh_keys *.json *.key
+recursive-include routersploit/resources/vendors *.dat
+recursive-include routersploit/resources/wordlists *.txt

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     download_url="https://github.com/threat9/routersploit/",
     packages=find_packages(),
     include_package_data=True,
+    scripts=('rsf.py',),
     entry_points={},
     install_requires=[
         "future",


### PR DESCRIPTION
Previously, when installing routersploit, rsf.py was not provided and several Python code and package files in routersploit/resources/ subdirectories were not installed.

This was noticed while working on wip/routersploit package on pkgsrc.

With the following commits routersploit is now completely self-contained,
provides the rsf.py script and all resource files making the packaging of it for
package systems trivial.

**READY**

Install rsf.py script and resources files as part of setup.py.