### PR TITLE
Requirements - Setting pysnmp version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 future
 requests
 paramiko
-pysnmp
+pysnmp==4.4.6
 pycryptodome
 pytest
 pytest-forked

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future
 requests
 paramiko
-pysnmp
+pysnmp==4.4.6
 pycryptodome


### PR DESCRIPTION
## Status
**READY**

## Description
This PR sets pysnmp requirement to version 4.4.6. Resolves #516 

## Verification
Provide steps to test or reproduce the PR.
 1. Do `./
 2. Start `./rsf.py`
 3. `use scanner/autopwn`
 4. `set target 192.168.1.1`
 5. `run`

## Checklist
- [x] Fix bug
