### PR TITLE
Adding tests for D-Link DSL-2780B & DSL-2730B & DSL-526B DNS Change

### DIFF
--- a/tests/exploits/routers/dlink/test_dsl_2730b_2780b_526b_dns_change.py
+++ b/tests/exploits/routers/dlink/test_dsl_2730b_2780b_526b_dns_change.py
@@ -1,0 +1,23 @@
+from routersploit.modules.exploits.routers.dlink.dsl_2730b_2780b_526b_dns_change import Exploit
+
+
+def test_check_success(target):
+    """ Test scenario - successful exploitation """
+
+    route_mock = target.get_route_mock("/dnscfg.cgi", methods=["POST"])
+    route_mock.return_value = (
+        "TEST"
+    )
+
+    exploit = Exploit()
+
+    assert exploit.target == ""
+    assert exploit.port == 80
+    assert exploit.dns1 == "8.8.8.8"
+    assert exploit.dns2 == "8.8.4.4"
+
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert exploit.check() is None
+    assert exploit.run() is None


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds tests for D-Link DSL-2780B & DSL-2730B & DSL-526B DNS Change module.

## Verification
 1. Execute `tests/exploits/routers/dlink/test_dsl_2730b_2780b_526b_dns_change.py`

## Checklist 
- [x] Write tests