### PR TITLE
support noninteractive mode

### DIFF
--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -265,14 +265,14 @@ class RoutersploitInterpreter(BaseInterpreter):
         set_opts = []
 
         try:
-            opts, args = getopt.getopt(argv,"hxm:s:",["module=", "set="])
+            opts, args = getopt.getopt(argv, "hxm:s:", ["module=", "set="])
         except getopt.GetoptError:
             print('rsf.py -m <module>')
             sys.exit(2)
         for opt, arg in opts:
             if opt == '-h':
-                print('msf.py -m <module> -s "<option> <value"')
-                sys.exit()
+                print('msf.py -x -m <module> -s "<option> <value"')
+                sys.exit(0)
             elif opt == '-x':
                 noninteractive = True
             elif opt in ("-m", "--module"):

--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -4,6 +4,7 @@ import atexit
 import itertools
 import os
 import sys
+import getopt
 import traceback
 from collections import Counter
 
@@ -220,6 +221,8 @@ class RoutersploitInterpreter(BaseInterpreter):
         self.modules_count.update([module.split('.')[0] for module in self.modules])
         self.main_modules_dirs = [module for module in os.listdir(MODULES_DIR) if not module.startswith("__")]
 
+        self.__handle_if_noninteractive(sys.argv[1:])
+
         self.__parse_prompt()
 
         self.banner = """ ______            _            _____       _       _ _
@@ -255,6 +258,37 @@ class RoutersploitInterpreter(BaseInterpreter):
         module_prompt_default_template = "\001\033[4m\002{host}\001\033[0m\002 (\001\033[91m\002{module}\001\033[0m\002) > "
         module_prompt_template = os.getenv("RSF_MODULE_PROMPT", module_prompt_default_template).replace('\\033', '\033')
         self.module_prompt_template = module_prompt_template if all(map(lambda x: x in module_prompt_template, ['{host}', "{module}"])) else module_prompt_default_template
+
+    def __handle_if_noninteractive(self, argv):
+        noninteractive = False
+        module = ''
+        set_opts = []
+
+        try:
+            opts, args = getopt.getopt(argv,"hxm:s:",["module=", "set="])
+        except getopt.GetoptError:
+            print('rsf.py -m <module>')
+            sys.exit(2)
+        for opt, arg in opts:
+            if opt == '-h':
+                print('msf.py -m <module> -s "<option> <value"')
+                sys.exit()
+            elif opt == '-x':
+                noninteractive = True
+            elif opt in ("-m", "--module"):
+                module = arg
+            elif opt in ("-s", "--set"):
+                set_opts.append(arg)
+
+        if noninteractive:
+            self.command_use(module)
+
+            for opt in set_opts:
+                self.command_set(opt)
+
+            self.command_exploit()
+
+            sys.exit(0)
 
     @property
     def module_metadata(self):


### PR DESCRIPTION
## Status

**READY**

## Description

Related to issue [Using routersploit in scripts](https://github.com/threat9/routersploit/issues/555)

This allows routersploit to be used in scripts by offering a `-x` flag for "execute command",  `-m` or `--module` for setting the module, and `-s` or `--set` to set options.

## Verification

### Make sure interactive mode isn't screwed up by this PR.

 1. `python ./rsf.py`
 2. `exit`

### Verify noninteractive mode

 1. `python ./rsf.py -x -m "scanners/autopwn" -s "target 10.0.0.1"`

## Checklist

- [x] Write module/feature 
- [ ] Write tests
- [ ] Document how it works

Because I didn't write a module, and there didn't appear to be pre-existing documentation on general usage (please let me know if there is), I wasn't sure where to put documentation for this but I'd be happy to write it. I wasn't really sure how to test it either but open to guidance, I just don't have that much of a python background with CLI stuff.
