### PR TITLE
Fix setup instructions to work on a clean Ubuntu installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ sudo add-apt-repository universe
 sudo apt-get install git python3-pip
 git clone https://www.github.com/threat9/routersploit
 cd routersploit
+python3 -m pip install setuptools
 python3 -m pip install -r requirements.txt
 python3 rsf.py
 ```


### PR DESCRIPTION
## Status
Ready

## Description
If followed exactly on a clean Ubuntu installation, the current master branch's installation instructions do not work. Running the command which installs dependencies from `requirements.txt` reports that `setuptools` is not installed. Installing `setuptools` manually fixes the issue, so I added it to the Ubuntu instructions. I haven't tested this on any other distro, so only the Ubuntu instructions were modified.

## Verification
 1. Get a clean Ubuntu installation (Use a VM or something)
 2. Clone the current master branch and follow the instructions in its `README.md` exactly; observe the error
 3. Clone this fork and follow the instructions in its `README.md` exactly; observe the error's absence


## Checklist
- [✓] Added one line to `README.md` 
