### PR TITLE
Avoid hardcoded relative paths

### DIFF
--- a/routersploit/core/exploit/payloads.py
+++ b/routersploit/core/exploit/payloads.py
@@ -125,9 +125,10 @@ class BasePayload(BaseExploit):
         encoders = []
 
         # get all encoders for given architecture
-        all_encoders = [e for e in index_modules() if "encoders.{}".format(architecture) in e]
+        all_encoders = [e for e in index_modules() if "encoders.{}".format(self.architecture) in e]
 
         for e in all_encoders:
+            encoder = e.replace("encoders.{}.".format(self.architecture), "").replace(".", "/")
             module = getattr(importlib.import_module('routersploit.modules' + e), "Encoder")
             encoders.append((
                 "{}/{}".format(self.architecture, encoder),

--- a/routersploit/core/exploit/payloads.py
+++ b/routersploit/core/exploit/payloads.py
@@ -22,6 +22,7 @@ from routersploit.core.exploit.printer import (
 )
 
 from routersploit.core.exploit.utils import (
+    index_modules,
     random_text,
 )
 
@@ -122,25 +123,18 @@ class BasePayload(BaseExploit):
         raise NotImplementedError()
 
     def get_encoders(self):
-        path = "routersploit/modules/encoders/{}".format(self.architecture)
-
         encoders = []
 
-        try:
-            files = os.listdir(path)
-        except FileNotFoundError:
-            return []
+        # get all encoders for given architecture
+        all_encoders = [e for e in index_modules() if "encoders.{}".format(architecture) in e]
 
-        for f in files:
-            if not f.startswith("__") and f.endswith(".py"):
-                encoder = f.replace(".py", "")
-                module_path = "{}/{}".format(path, encoder).replace("/", ".")
-                module = getattr(importlib.import_module(module_path), "Encoder")
-                encoders.append((
-                    "{}/{}".format(self.architecture, encoder),
-                    module._Encoder__info__["name"],
-                    module._Encoder__info__["description"],
-                ))
+        for e in all_encoders:
+            module = getattr(importlib.import_module('routersploit.modules' + e), "Encoder")
+            encoders.append((
+                "{}/{}".format(self.architecture, encoder),
+                module._Encoder__info__["name"],
+                module._Encoder__info__["description"],
+            ))
 
         return encoders
 

--- a/routersploit/core/exploit/payloads.py
+++ b/routersploit/core/exploit/payloads.py
@@ -129,7 +129,7 @@ class BasePayload(BaseExploit):
 
         for e in all_encoders:
             encoder = e.replace("encoders.{}.".format(self.architecture), "").replace(".", "/")
-            module = getattr(importlib.import_module('routersploit.modules' + e), "Encoder")
+            module = getattr(importlib.import_module('routersploit.modules.' + e), "Encoder")
             encoders.append((
                 "{}/{}".format(self.architecture, encoder),
                 module._Encoder__info__["name"],

--- a/routersploit/core/exploit/payloads.py
+++ b/routersploit/core/exploit/payloads.py
@@ -1,4 +1,3 @@
-import os
 import importlib
 from collections import namedtuple
 from struct import pack

--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -4,8 +4,6 @@ import binascii
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import threading
 import time
-from os import listdir
-from os.path import isfile, join
 import importlib
 
 from routersploit.core.exploit.printer import (

--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -28,10 +28,10 @@ def shell(exploit, architecture="", method="", payloads=None, **params):
 
     if architecture and method:
         # get all payloads for given architecture
-        all_payloads = [p for p in index_modules() if "payloads.{}".format(architecture) in p]
+        all_payloads = [p.lstrip('payloads.').replace('.', '/') for p in index_modules() if "payloads.{}".format(architecture) in p]
 
         for p in all_payloads:
-            module = getattr(importlib.import_module('routersploit.modules.' + p), 'Payload')
+            module = getattr(importlib.import_module('routersploit.modules.payloads.' + p.replace('/', '.')), 'Payload')
 
             # if method/arch is cmd then filter out payloads
             if method is "cmd":

--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -18,6 +18,7 @@ from routersploit.core.exploit.printer import (
 )
 
 from routersploit.core.exploit.utils import (
+    index_modules,
     random_text,
 )
 
@@ -28,14 +29,11 @@ def shell(exploit, architecture="", method="", payloads=None, **params):
     options = []
 
     if architecture and method:
-        path = "routersploit/modules/payloads/{}/".format(architecture)
-
         # get all payloads for given architecture
-        all_payloads = [f.split(".")[0] for f in listdir(path) if isfile(join(path, f)) and f.endswith(".py") and f != "__init__.py"]
+        all_payloads = [p for p in index_modules() if "payloads.{}".format(architecture) in p]
 
-        payload_path = path.replace("/", ".")
         for p in all_payloads:
-            module = getattr(importlib.import_module("{}{}".format(payload_path, p)), 'Payload')
+            module = getattr(importlib.import_module('routersploit.modules.' + p), 'Payload')
 
             # if method/arch is cmd then filter out payloads
             if method is "cmd":

--- a/routersploit/core/exploit/utils.py
+++ b/routersploit/core/exploit/utils.py
@@ -6,12 +6,14 @@ import random
 from functools import wraps
 
 import routersploit.modules as rsf_modules
+import routersploit.resources as resources
 import routersploit.resources.wordlists as wordlists
 
 from routersploit.core.exploit.printer import print_error, print_info
 from routersploit.core.exploit.exceptions import RoutersploitException
 
 MODULES_DIR = rsf_modules.__path__[0]
+RESOURCES_DIR = resources.__path__[0]
 WORDLISTS_DIR = wordlists.__path__[0]
 
 
@@ -211,16 +213,17 @@ def stop_after(space_number):
     return _outer_wrapper
 
 
-def lookup_vendor(addr: str) -> str:
+def lookup_vendor(addr: str, resources_directory: str = RESOURCES_DIR) -> str:
     """ Lookups vendor (manufacturer) based on MAC address
 
     :param str addr: MAC address to lookup
+    :param str resources_directory: path to resources directory
     :return str: vendor name from oui.dat database
     """
 
     addr = addr.upper().replace(":", "")
 
-    path = "./routersploit/resources/vendors/oui.dat"
+    path = os.path.join(resources_directory, "vendors/oui.dat")
     with open(path, "r") as f:
         for line in f.readlines():
             line = line.strip()

--- a/routersploit/modules/exploits/generic/ssh_auth_keys.py
+++ b/routersploit/modules/exploits/generic/ssh_auth_keys.py
@@ -51,7 +51,7 @@ class Exploit(SSHClient):
         self.valid = None
         self.private_keys = []
 
-        ssh_keys_path = "./routersploit/resources/ssh_keys"
+        ssh_keys_path = os.path.join(utils.RESOURCES_DIR, "ssh_keys")
         ssh_keys = [".".join(filename.split(".")[:-1]) for filename in os.listdir(ssh_keys_path) if filename.endswith(".json")]
 
         for ssh_key in ssh_keys:

--- a/routersploit/modules/scanners/autopwn.py
+++ b/routersploit/modules/scanners/autopwn.py
@@ -34,8 +34,8 @@ class Exploit(Exploit):
         self.vulnerabilities = []
         self.creds = []
         self.not_verified = []
-        self._exploits_directories = [path.join("routersploit/modules/exploits/", module) for module in self.modules]
-        self._creds_directories = [path.join("routersploit/modules/creds/", module) for module in self.modules]
+        self._exploits_directories = [path.join(utils.MODULES_DIR, "exploits", module) for module in self.modules]
+        self._creds_directories = [path.join(utils.MODULES_DIR, "creds", module) for module in self.modules]
 
     def run(self):
         self.vulnerabilities = []


### PR DESCRIPTION
## Status
**READY**

## Description
Describe what is changed by your Pull Request. If this PR is related to the open issue (bug/feature/new module) please attach issue number.

## Verification
Provide steps to test or reproduce the PR.

 1. Install routersploit, e.g. via pkgsrc wip/routersploit
 2. Start `./rsf.py`
 3. `use scanners/autopwn`
 4. `set target 192.168.1.1`
 5. `run`

...then watch threads ~suddendly terminating without invoking any module:

````
[...]
[*] Running module...
-
[*] Starting vulnerablity check...
[*] thread-0 thread is starting...
[*] thread-1 thread is starting...
[...]
[*] thread-0 thread is terminated.
[*] thread-1 thread is terminated.
[...]
-
[*] Elapsed time: 0.0001952648162841797 seconds
-
[*] Starting default credentials check...
[*] thread-0 thread is starting...
[*] thread-1 thread is starting...
[...]
[*] thread-0 thread is terminated.
[*] thread-1 thread is terminated.
[...]
-
[*] Elapsed time: 0.00017380714416503906 seconds
[...]
````

At least ktruss-ing it reveals that several open("routersploit/...")
fails due ENOENT.  If the $PWD is ${PYSITELIB} (e.g.
`/usr/pkg/lib/python3.7/site-packages/`, where `routersploit/...`
installed hierarcy is present) and then directly invoking routersploit
in the python interpreter via:

````
>>> from routersploit.interpreter import RoutersploitInterpreter
>>> rsf = RoutersploitInterpreter()
>>> rsf.start()
````

routersploit works!

Proposed commits should avoid uses of hardcoded relative paths and
fixes this problem.

## Checklist
- [x] Write module/feature