### PR TITLE
Fixing lint errors

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -20,4 +20,5 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     source ~/.venv/bin/activate
 fi
 
+python -m pip install --upgrade pip
 python -m pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ requests
 paramiko
 pysnmp==4.4.6
 pycryptodome
-pytest
+pytest==4.4.0
 pytest-forked
 pytest-xdist
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ requests
 paramiko
 pysnmp==4.4.6
 pycryptodome
-pytest==3.6.0
+pytest
 pytest-forked
 pytest-xdist
 flake8

--- a/routersploit/core/bluetooth/btle/btle_device.py
+++ b/routersploit/core/bluetooth/btle/btle_device.py
@@ -30,7 +30,7 @@ class Device(ScanEntry):
     def _update(self, resp):
         ScanEntry._update(self, resp)
 
-        if self.addrType is "random":
+        if self.addrType == "random":
             self.vendor = "None (Random MAC address)"
         else:
             self.vendor = lookup_vendor(self.addr)

--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -38,7 +38,7 @@ def shell(exploit, architecture="", method="", payloads=None, **params):
             module = getattr(importlib.import_module("{}{}".format(payload_path, p)), 'Payload')
 
             # if method/arch is cmd then filter out payloads
-            if method is "cmd":
+            if method == "cmd":
                 if getattr(module, "cmd") in payloads:
                     available_payloads[p] = module
             else:

--- a/routersploit/modules/exploits/routers/ipfire/ipfire_oinkcode_rce.py
+++ b/routersploit/modules/exploits/routers/ipfire/ipfire_oinkcode_rce.py
@@ -75,7 +75,7 @@ class Exploit(HTTPClient):
         if response is None:
             return False  # target is not vulnerable
 
-        if response.status_code is 200:
+        if response.status_code == 200:
             res = re.findall(r"IPFire ([\d.]{4}) \([\w]+\) - Core Update ([\d]+)", response.text)
             if res:
                 version = res[0][0]


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes errors with lint:
```
+make lint tests
python3 -m flake8 --exclude=.git,rsf.py --ignore=E501,F405,F403,W504 .
./routersploit/core/bluetooth/btle/btle_device.py:33:12: F632 use ==/!= to compare str, bytes, and int literals
./routersploit/core/exploit/shell.py:41:16: F632 use ==/!= to compare str, bytes, and int literals
./routersploit/modules/exploits/routers/ipfire/ipfire_oinkcode_rce.py:78:12: F632 use ==/!= to compare str, bytes, and int literals
```

## Verification
Provide steps to test or reproduce the PR.
 1. Run `make lint`

## Checklist
- [x] Fix bug
