### PR TITLE
Fixing payload import

### DIFF
--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -28,10 +28,10 @@ def shell(exploit, architecture="", method="", payloads=None, **params):
 
     if architecture and method:
         # get all payloads for given architecture
-        all_payloads = [p.lstrip('payloads.').replace('.', '/') for p in index_modules() if "payloads.{}".format(architecture) in p]
+        all_payloads = [p.replace("payloads.", "").replace(".", "/") for p in index_modules() if "payloads.{}".format(architecture) in p]
 
         for p in all_payloads:
-            module = getattr(importlib.import_module('routersploit.modules.payloads.' + p.replace('/', '.')), 'Payload')
+            module = getattr(importlib.import_module("routersploit.modules.payloads." + p.replace("/", ".")), "Payload")
 
             # if method/arch is cmd then filter out payloads
             if method == "cmd":


### PR DESCRIPTION
## Status
**READY**

## Description
This PR fixes #584 bug. The bug boils down to:
```
>>> "payloads.armle.bind_tcp".lstrip("payloads")
'.armle.bind_tcp'
>>> "payloads.armle.bind_tcp".lstrip("payloads.")
'rmle.bind_tcp'
```

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/cameras/mvpower/dvr_jaws_rce`
 3. `set target 192.168.1.1`
 4. `run`

## Checklist
- [x] Implement fix
