### PR TITLE
Fixing wordlist creds parsing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 future
-requests
+requests==2.21.0
 paramiko
 pysnmp==4.4.6
 pycryptodome

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future
-requests
+requests==2.21.0
 paramiko
 pysnmp==4.4.6
 pycryptodome

--- a/routersploit/modules/creds/cameras/acti/webinterface_http_form_default_creds.py
+++ b/routersploit/modules/creds/cameras/acti/webinterface_http_form_default_creds.py
@@ -48,7 +48,7 @@ class Exploit(HTTPClient):
     def target_function(self, running, creds):
         while running.is_set():
             try:
-                username, password = creds.next().split(":")
+                username, password = creds.next().split(":", 1)
 
                 data = {
                     "LOGIN_ACCOUNT": username,

--- a/routersploit/modules/creds/cameras/basler/webinterface_http_form_default_creds.py
+++ b/routersploit/modules/creds/cameras/basler/webinterface_http_form_default_creds.py
@@ -48,7 +48,7 @@ class Exploit(HTTPClient):
     def target_function(self, running, creds):
         while running.is_set():
             try:
-                username, password = creds.next().split(":")
+                username, password = creds.next().split(":", 1)
 
                 data = {
                     "Auth.Username": username,

--- a/routersploit/modules/creds/generic/ftp_default.py
+++ b/routersploit/modules/creds/generic/ftp_default.py
@@ -49,7 +49,7 @@ class Exploit(FTPClient):
     def target_function(self, running, data):
         while running.is_set():
             try:
-                username, password = data.next().split(":")
+                username, password = data.next().split(":", 1)
             except StopIteration:
                 break
             else:

--- a/routersploit/modules/creds/generic/http_basic_digest_default.py
+++ b/routersploit/modules/creds/generic/http_basic_digest_default.py
@@ -56,7 +56,7 @@ class Exploit(HTTPClient):
     def target_function(self, running, data):
         while running.is_set():
             try:
-                username, password = data.next().split(":")
+                username, password = data.next().split(":", 1)
 
                 if self.auth_type == "digest":
                     auth = HTTPDigestAuth(username, password)

--- a/routersploit/modules/creds/generic/ssh_default.py
+++ b/routersploit/modules/creds/generic/ssh_default.py
@@ -50,7 +50,7 @@ class Exploit(SSHClient):
     def target_function(self, running, data):
         while running.is_set():
             try:
-                username, password = data.next().split(":")
+                username, password = data.next().split(":", 1)
                 ssh_client = self.ssh_create()
                 if ssh_client.login(username, password):
                     if self.stop_on_success:

--- a/routersploit/modules/creds/generic/telnet_default.py
+++ b/routersploit/modules/creds/generic/telnet_default.py
@@ -50,7 +50,7 @@ class Exploit(TelnetClient):
     def target_function(self, running, data):
         while running.is_set():
             try:
-                username, password = data.next().split(":")
+                username, password = data.next().split(":", 1)
                 telnet_client = self.telnet_create()
                 if telnet_client.login(username, password, retries=3):
                     if self.stop_on_success:

--- a/routersploit/modules/creds/routers/mikrotik/api_ros_default_creds.py
+++ b/routersploit/modules/creds/routers/mikrotik/api_ros_default_creds.py
@@ -47,7 +47,7 @@ class Exploit(TCPClient):
     def target_function(self, running, creds):
         while running.is_set():
             try:
-                username, password = creds.next().split(":")
+                username, password = creds.next().split(":", 1)
 
                 tcp_client = self.tcp_create()
                 tcp_sock = tcp_client.connect()

--- a/routersploit/modules/creds/routers/pfsense/webinterface_http_form_default_creds.py
+++ b/routersploit/modules/creds/routers/pfsense/webinterface_http_form_default_creds.py
@@ -45,7 +45,7 @@ class Exploit(HTTPClient):
             print_error("Credentials not found")
 
     def target_function(self, data):
-        username, password = data.split(":")
+        username, password = data.split(":", 1)
 
     def check(self):
         response = self.http_request(


### PR DESCRIPTION
## Status
**READY**

## Description
This PR fixes wordlist creds parsing. Resolves #601 and #604 

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use creds/generic/ssh_default`
 3. `set target 192.168.1.1`
 4. `run`

## Checklist
- [x] Fix bug
