### PR TITLE
Do not update the same dict while iterating (fixes #623)

### DIFF
--- a/routersploit/core/exploit/exploit.py
+++ b/routersploit/core/exploit/exploit.py
@@ -42,7 +42,7 @@ class ExploitOptionsAggregator(type):
         else:
             attrs["exploit_attributes"] = {k: v for d in base_exploit_attributes for k, v in iteritems(d)}
 
-        for key, value in iteritems(attrs):
+        for key, value in iteritems(attrs.copy()):
             if isinstance(value, Option):
                 value.label = key
                 attrs["exploit_attributes"].update({key: [value.display_value, value.description, value.advanced]})


### PR DESCRIPTION
Fixes compatibility with Python 3.8.

## Status
**READY**

## Description
Changing a dict while iterating over it was an undefined behavior and is now forbidden in new Python. Running routersploit will fail with the error in #623. This simple change fixes this.
