### PR TITLE
Fix potential FP in rom-0 exploit

### DIFF
--- a/routersploit/modules/exploits/routers/multi/rom0.py
+++ b/routersploit/modules/exploits/routers/multi/rom0.py
@@ -92,7 +92,7 @@ class Exploit(HTTPClient):
 
             if response is not None \
                     and response.status_code == 200 \
-                    and "<html>" not in response.text \
+                    and "<html" not in response.text \
                     and len(response.text) > 500:
                 return True
 


### PR DESCRIPTION
## Status
**READY**

## Description
There is a chance that the exploits/routers/multi/rom0 module's check function will result in a false positive. In the check function, it downloads the rom-0 file from the router, then checks to see if `<html>` is in the response content. This does not account for the possibility that the html tag has other attributes attached to it. I encounter this false positive on a Arris router model number TG1682G. This router returns the login html page when you request `http://192.168.1.1/rom0`. This login page's html tag looks like this:

```
...
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
...
</html>
```

Since the module was looking for just `<html>`, it would false positve and say the router was vulnerable. 

The false positive shows itself in a weird way.  The module downloads the http://192.168.1.1/rom-0 file, which may just be the login html. The module will then try to decompress the html and crash.
```
[*] Running module exploits/routers/multi/rom0...
[+] Target is vulnerable
[*] Downloading rom-0 file...
[*] Extracting password from file...
Traceback (most recent call last):
  File "/routersploit/routersploit/interpreter.py", line 389, in command_run
    self.current_module.run()
  File "/routersploit/routersploit/modules/exploits/routers/multi/rom0.py", line 60, in run
    password = self.extract_password(response.content)
  File "/routersploit/routersploit/modules/exploits/routers/multi/rom0.py", line 70, in extract_password
    result, window = LZSDecompress(data[fpos:])
  File "/routersploit/routersploit/libs/lzs/lzs.py", line 131, in LZSDecompress
    char = window[-offset]
  File "/routersploit/routersploit/libs/lzs/Since the html tag has extra attributes to it, this will cause a false positive.lzs.py", line 86, in __getitem__
    return self.__data__[n]
IndexError: deque index out of range
```

The fix for this is simple. All you need to check for in the response content is `<html` instead of `<html>`.

## Verification
 1. Start `./rsf.py`
 2. `use exploits/routers/multi/rom0`
 3. `set target 192.168.1.1`
 4. `run`
 5.  Since we're looking for just  `<html` the false positive will be averted.
```
[*] Running module exploits/routers/multi/rom0...
[-] Target is not vulnerable
```

## Checklist
I don't think any of these are necessary for such a small fix.
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
