### PR TITLE
Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It consists of various modules that aids penetration testing operations:
 * creds - modules designed to test credentials against network services
 * scanners - modules that check if a target is vulnerable to any exploit
 * payloads - modules that are responsible for generating payloads for various architectures and injection points
-* generic - modules that perform generic attacks 
+* generic - modules that perform generic attacks
 
 # Installation
 
@@ -27,7 +27,11 @@ Required:
 * pycrypto
 
 Optional:
-* bluepy - bluetooth low energy 
+* bluepy - bluetooth low energy
+
+#### Additional requirements for Windows:
+* pyreadline (replacement for linux's readline module)
+* colorama (makes colored output can be displayed on Windows's command prompt)
 
 ## Installation on Kali Linux
 
@@ -75,6 +79,15 @@ sudo python3 -m pip install -r requirements.txt
 python3 rsf.py
 ```
 
+## Installation on Windows
+
+```
+git clone https://github.com/threat9/routersploit
+cd routersploit
+python3 -m pip install -r requirements.txt
+python3 setup.py install
+```
+
 ## Running on Docker
 
 ```
@@ -94,17 +107,17 @@ git pull
 ```
 
 # Build your own
-To our surprise people started to fork 
-[routersploit](https://github.com/threat9/routersploit) not because they were 
-interested in the security of embedded devices but simply because they want to 
-leverage our interactive shell logic and build their own tools using similar 
-concept. All these years they must have said: _"There must be a better way!"_ 
-and they were completely right, the better way is called 
+To our surprise people started to fork
+[routersploit](https://github.com/threat9/routersploit) not because they were
+interested in the security of embedded devices but simply because they want to
+leverage our interactive shell logic and build their own tools using similar
+concept. All these years they must have said: _"There must be a better way!"_
+and they were completely right, the better way is called
 [_Riposte_](https://github.com/fwkz/riposte).
 
-[_Riposte_](https://github.com/fwkz/riposte) allows you to easily wrap your 
-application inside a tailored interactive shell. Common chores regarding 
-building REPLs was factored out and being taken care of so you can really 
+[_Riposte_](https://github.com/fwkz/riposte) allows you to easily wrap your
+application inside a tailored interactive shell. Common chores regarding
+building REPLs was factored out and being taken care of so you can really
 focus on specific domain logic of your application.
 # License
 

--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -41,7 +41,7 @@ if sys.platform == "win32":
     colorama.init(autoreset = True)
 
 def is_libedit():
-    return "libedit" in readline.__doc__
+    return "libedit" in (readline.__doc__ or "")
 
 
 class BaseInterpreter(object):

--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -36,7 +36,7 @@ from routersploit.core.exploit.exploit import GLOBAL_OPTS
 from routersploit.core.exploit.payloads import BasePayload
 
 import readline
-if sys.platform is "win32":
+if sys.platform == "win32":
     import colorama
     colorama.init(autoreset = True)
 

--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -36,7 +36,9 @@ from routersploit.core.exploit.exploit import GLOBAL_OPTS
 from routersploit.core.exploit.payloads import BasePayload
 
 import readline
-
+if sys.platform is "win32":
+    import colorama
+    colorama.init(autoreset = True)
 
 def is_libedit():
     return "libedit" in readline.__doc__

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,34 @@
+from sys import platform
 from setuptools import setup, find_packages
 
 
-with open("README.md", "r") as f:
-    long_description = f.read()
+README = open("README.md", "r").read()
+DEPENDENCIES = open("requirements.txt", "r").read().split("\n")
+if platform is "win32":
+    DEPENDENCIES += ["colorama", "pyreadline"]
 
-setup(
-    name="routersploit",
-    version="3.4.0",
-    description="Exploitation Framework for Embedded Devices",
-    long_description=long_description,
-    author="Threat9",
-    author_email="marcin@threat9.com",
-    url="https://www.threat9.com",
-    download_url="https://github.com/threat9/routersploit/",
-    packages=find_packages(),
-    include_package_data=True,
-    scripts=('rsf.py',),
-    entry_points={},
-    install_requires=[
-        "future",
-        "requests",
-        "paramiko",
-        "pysnmp",
-        "pycryptodome",
-    ],
-    extras_require={
+setup(name = "routersploit",
+      version = "3.4.0",
+      description = "Exploitation Framework for Embedded Devices",
+      long_description = README,
+      author = "Threat9",
+      author_email = "marcin@threat9.com",
+      url = "https://www.threat9.com",
+      download_url = "https://github.com/threat9/routersploit/",
+      packages = find_packages(),
+      include_package_data = True,
+      scripts = ("rsf.py",),
+      entry_points = {},
+      install_requires = DEPENDENCIES,
+      extras_require = {
         "tests": [
             "pytest",
             "pytest-forked",
             "pytest-xdist",
             "flake8",
         ],
-    },
-    classifiers=[
+      },
+      classifiers = [
         "Operating System :: POSIX",
         "Environment :: Console",
         "Environment :: Console :: Curses",
@@ -48,5 +44,5 @@ setup(
         "Topic :: Security",
         "Topic :: System :: Networking",
         "Topic :: Utilities",
-    ],
+      ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 README = open("README.md", "r").read()
 DEPENDENCIES = open("requirements.txt", "r").read().split("\n")
-if platform is "win32":
+if platform == "win32":
     DEPENDENCIES += ["colorama", "pyreadline"]
 
 setup(name = "routersploit",


### PR DESCRIPTION
## Status
**READY**

## Description
This pull request adds support for Windows by initializing colorama when loading the interpreter module, so colored output can be printed to Windows's command prompt, and by using pyreadline on Windows systems as a replacement for Linux's readline module.
Closes [Issue #619 ](https://github.com/threat9/routersploit/issues/619)

## Verification
Provide steps to test or reproduce the PR.

1. Clone `git clone https://github.com/threat9/routersploit && cd routersploit`
2. Install `python3 setup.py install`
3. Execute `rsf`


## Checklist
- [X] Write feature
- [X] Document [Additional requirements](https://github.com/threat9/routersploit#Additional-requirements-for-Windows) and [Installation on Windows](https://github.com/threat9/routersploit#Installation-on-Windows)
