### PR TITLE
Lowers the chances of a false positive

### DIFF
--- a/routersploit/modules/exploits/routers/multi/rom0.py
+++ b/routersploit/modules/exploits/routers/multi/rom0.py
@@ -92,7 +92,7 @@ class Exploit(HTTPClient):
 
             if response is not None \
                     and response.status_code == 200 \
-                    and "<html>" not in response.text \
+                    and "</html>" not in response.text \
                     and len(response.text) > 500:
                 return True
 


### PR DESCRIPTION
Using <html> might make the scanner count a false positive if it encounters a custom HTML page created by some ISPs. Using </html> lowers that chance since the closing tag does not contain any attributes (e.g. xmlns). These false positives could be the route cause for bug reports such as https://github.com/threat9/routersploit/issues/577

## Status
READY

## Description
Using <html> might make the scanner count a false positive if it encounters a custom HTML page created by some ISPs. Using </html> lowers that chance since the closing tag does not contain any attributes (e.g. xmlns). These false positives could be the route cause for bug reports such as https://github.com/threat9/routersploit/issues/577

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use scanners/routers/router_scan`
 3. `set target 192.168.1.1`
 4. `run`

Before patch, if the router returned any kind of HTML page where `<html>` had the `xmlns` attribute, the scanner would return a false positive.