### PR TITLE
Fix exploit check for routers/linksys/test_eseries_themoon_rce.

### DIFF
--- a/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
+++ b/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
@@ -78,6 +78,22 @@ class Exploit(HTTPClient):
 
     @mute
     def check(self):
+        # See https://isc.sans.edu/diary/Linksys+Worm+%22TheMoon%22+Summary%3A+What+we+know+so+far/17633
+        response = self.http_request(
+            method="GET",
+            path="/HNAP1/",
+            headers={'Host': 'test'}
+        )
+
+        if not(response):
+            return False  # target is not vulnerable
+
+        content = response.content
+        if content and content.find(b'ModelName') == -1:
+            return False  # target is not vulnerable
+
+        # target may be vulnerable
+
         response = self.http_request(
             method="GET",
             path="/tmUnblock.cgi",

--- a/tests/exploits/routers/linksys/test_eseries_themoon_rce.py
+++ b/tests/exploits/routers/linksys/test_eseries_themoon_rce.py
@@ -6,6 +6,9 @@ from routersploit.modules.exploits.routers.linksys.eseries_themoon_rce import Ex
 def test_check_success(mocked_shell, target):
     """ Test scenario - successful check """
 
+    route_mock = target.get_route_mock("/HNAP1/", methods=["GET"])
+    route_mock.return_value = "<ModelName>E2500</ModelName>"
+
     route_mock = target.get_route_mock("/tmUnblock.cgi", methods=["GET", "POST"])
     route_mock.return_value = ""
 
@@ -15,3 +18,31 @@ def test_check_success(mocked_shell, target):
 
     assert exploit.check()
     assert exploit.run() is None
+
+
+@mock.patch("routersploit.modules.exploits.routers.linksys.eseries_themoon_rce.shell")
+def test_check_unsuccess_no_hnapi(mocked_shell, target):
+    """ Test scenario - unsuccessful check (no successful /HNAPI/ response)"""
+
+    route_mock = target.get_route_mock("/tmUnblock.cgi", methods=["GET", "POST"])
+    route_mock.return_value = ""
+
+    exploit = Exploit()
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert not(exploit.check())
+
+
+@mock.patch("routersploit.modules.exploits.routers.linksys.eseries_themoon_rce.shell")
+def test_check_success_no_cgi(mocked_shell, target):
+    """ Test scenario - unsuccessful check (no successful /tmUnblock.cgi response)"""
+
+    route_mock = target.get_route_mock("/HNAP1/", methods=["GET"])
+    route_mock.return_value = "<ModelName>E2500</ModelName>"
+
+    exploit = Exploit()
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert not(exploit.check())


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes in accordance with the [vulnerability write-up](https://isc.sans.edu/forums/diary/Linksys+Worm+TheMoon+Summary+What+we+know+so+far/17633/), a false-positive check against a Zyxel C3000Z router (and likely other routers).

The Zyxel C3000Z responds as follows to the exploit URI:
```
$ curl http://192.168.0.1/tmUnblock.cgi
<html>
<head>
<script type="text/javascript">
top.location='login.html';
</script>
</head>
</html>
```

The [Linksys Worm "TheMoon" Summary: What we know so far](https://isc.sans.edu/forums/diary/Linksys+Worm+TheMoon+Summary+What+we+know+so+far/17633/) writeup describes checking for potentially vulnerable hosts like so:
```
echo "GET /HNAP1/ HTTP/1.1\r\nHost: test\r\n\r\n" | nc routerip 8080
```

Again, the Zyxel C3000Z responds as follows to the `/HNAP1/` URI:
```
$ curl http://192.168.0.1/HNAP1/
<html>
<head>
<script type="text/javascript">
top.location='login.html';
</script>
</head>
</html>
```

The fix is to:
1. GET request to `/HNAP1/` (including the `Host` header as in the writeup).
2. Check for the presence of `ModelName` (suggesting a legal HNAP XML document).
3. Continue to the remainder of the existing check logic.

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/linksys/eseries_themoon_rce`
 3. `set target 192.168.0.1`
 4. `check`

## Checklist
- [x] Update check
- [x] Update tests

## Note
Thanks for providing this tool to the community and for your ongoing support. It gave me some comfort to know that my router wasn't vulnerable to anything the `autopwn` scanner found.
