### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/routersploit/core/exploit/exploit.py
+++ b/routersploit/core/exploit/exploit.py
@@ -111,7 +111,7 @@ class Exploit(BaseExploit):
 
         start = time.time()
         try:
-            while thread.isAlive():
+            while thread.is_alive():
                 thread.join(1)
 
         except KeyboardInterrupt:


### PR DESCRIPTION
## Status

READY

## Description

Fixes #711 by using `is_alive` which is present in both Python 2.7 and Python 3

## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
