### PR TITLE
Add Aztech Globe DSL5068EN-1T1R default telnet creds

### DIFF
--- a/routersploit/resources/wordlists/defaults.txt
+++ b/routersploit/resources/wordlists/defaults.txt
@@ -159,6 +159,7 @@ admin:2222
 admin:22222
 admin:2601hx
 admin:362729
+admin:3UJUh2VemEfUtesEchEC2d2e
 admin:4321
 admin:54321
 admin:7ujMko0admin


### PR DESCRIPTION
## Status
**READY**

## Description
Add Aztech Globe DSL5068EN-1T1R default telnet creds. Reference https://kbeflo.github.io/2018/12/20/Aztech-Globe-DSL5068EN-1T1R-WiFi-Password-using-Telnet
