### PR TITLE
Updated exploit.py for compatibility with Python 3.9

### DIFF
--- a/routersploit/core/exploit/exploit.py
+++ b/routersploit/core/exploit/exploit.py
@@ -111,7 +111,7 @@ class Exploit(BaseExploit):
 
         start = time.time()
         try:
-            while thread.isAlive():
+            while thread.is_alive():
                 thread.join(1)
 
         except KeyboardInterrupt:


### PR DESCRIPTION
The .isAlive method for threads is deprecated in python 3.9. This pull request contains an updated version of exploit.py that uses the .is_alive() method instead.

## Status
READY

## Description
Currently, routersploit throws the following error when utilising /routersploit/core/exploit/exploit.py due to the method .isAlive being deprecated in python 3.9. This pull request modifies exploit.py to use the .is_alive method instead to ensure compatibility with newer versions of python3.

> Traceback (most recent call last):
>   File "/Users/RohanBarar/Desktop/routersploit/routersploit/interpreter.py", line 389, in command_run
>     self.current_module.run()
>   File "/Users/RohanBarar/Desktop/routersploit/routersploit/modules/scanners/autopwn.py", line 81, in run
>     self.run_threads(self.threads, self.exploits_target_function, data)
>   File "/Users/RohanBarar/Desktop/routersploit/routersploit/core/exploit/exploit.py", line 114, in run_threads
>     while thread.isAlive():
> AttributeError: 'Thread' object has no attribute 'isAlive'

This error is entirely corrected in this pull request.

## Verification
Steps to reproduce the issue (on python 3.9.1).
 1. python rsf.py
 2. use scanners/autopwn
 3. exploit