### PR TITLE
docs: fix simple typo, vulnerabilty -> vulnerability

### DIFF
--- a/routersploit/modules/exploits/routers/zte/f460_f660_backdoor.py
+++ b/routersploit/modules/exploits/routers/zte/f460_f660_backdoor.py
@@ -9,7 +9,7 @@ class Exploit(HTTPClient):
         "description": "Exploits ZTE F460 and F660 backdoor vulnerability that allows "
                        "executing commands on operating system level.",
         "authors": (
-            "Rapid7",  # vulnerabilty discovery
+            "Rapid7",  # vulnerability discovery
             "Marcin Bury <marcin[at]threat9.com>",  # routersploit module
         ),
         "references": (


### PR DESCRIPTION
There is a small typo in routersploit/modules/exploits/routers/zte/f460_f660_backdoor.py.

Should read `vulnerability` rather than `vulnerabilty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md