### PR TITLE
Fix  better detection of vulnerable router for linksys/eseries_themoon_rce exploit

### DIFF
--- a/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
+++ b/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
@@ -83,7 +83,7 @@ class Exploit(HTTPClient):
             path="/tmUnblock.cgi",
         )
 
-        if response and response.status_code in [200, 301, 302] and not any(i in response.text.lower() for i in["page not found","error","404","not found"]) :
+        if response and response.status_code in [200, 301, 302] and not any(i in response.text.lower() for i in ["page not found", "error", "404", "not found"]):
             return True  # target is vulnerable
 
         return False  # target is not vulnerable

--- a/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
+++ b/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
@@ -83,7 +83,7 @@ class Exploit(HTTPClient):
             path="/tmUnblock.cgi",
         )
 
-        if response and response.status_code in [200, 301, 302]:
+        if response and response.status_code in [200, 301, 302] and not any(i in response.text.lower() for i in["page not found","error","404","not found"]) :
             return True  # target is vulnerable
 
         return False  # target is not vulnerable


### PR DESCRIPTION
## Status
**READY

## Description
Better detection of vulnerable router in the exploit routers/linksys/eseries_themoon_rce
The exploit checks whether the returned response code is 200,301 or 302 but some webpages uses custom 404 which makes them look as 200 OK so the exploit assumes the  machine is vulnerable but it is not.

## Verification
 1. Start `./rsf.py`
 2. `use exploits/routers/linksys/eseries_themoon_rce`
 3. `set target 192.168.1.1`
 4. `check`
 
##Note
My router wasn't vulnerable to it but it returned as vulnnerable even `autopwn` also returned vulnerable