### PR TITLE
Fix printer bug that causes uncatched exception.

### DIFF
--- a/routersploit/core/exploit/printer.py
+++ b/routersploit/core/exploit/printer.py
@@ -134,7 +134,7 @@ def print_table(headers, *args, **kwargs) -> None:
         for idx, element in enumerate(arg):
             content_line = "".join((
                 content_line,
-                "{:<{}}".format(element, fill[idx])
+                "{:<{}}".format(str(element), fill[idx])
             ))
         print_info(content_line)
 


### PR DESCRIPTION
## Status
**READY**

## Description
Just fixed this bug:

```
Traceback (most recent call last):
  File "/root/routersploit/routersploit/interpreter.py", line 389, in command_run
    self.current_module.run()
  File "/root/routersploit/routersploit/modules/generic/bluetooth/btle_scan.py", line 25, in run
    device.print_info()
  File "/root/routersploit/routersploit/core/bluetooth/btle/btle_device.py", line 56, in print_info
    print_table(headers, *data, max_column_length=70, extra_fill=3)
  File "/root/routersploit/routersploit/core/exploit/printer.py", line 137, in print_table
    "{:<{}}".format(element, fill[idx])
TypeError: unsupported format string passed to NoneType.__format__

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "rsf.py", line 29, in <module>
    routersploit(sys.argv)
  File "rsf.py", line 25, in routersploit
    rsf.start()
  File "/root/routersploit/routersploit/interpreter.py", line 125, in start
    command_handler(args, **kwargs)
  File "/root/routersploit/routersploit/core/exploit/utils.py", line 177, in wrapper
    return fn(self, *args, **kwargs)
  File "/root/routersploit/routersploit/interpreter.py", line 394, in command_run
    print_error(traceback.format_exc(sys.exc_info()))
  File "/usr/lib/python3.8/traceback.py", line 167, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "/usr/lib/python3.8/traceback.py", line 120, in format_exception
    return list(TracebackException(
  File "/usr/lib/python3.8/traceback.py", line 509, in __init__
    self.stack = StackSummary.extract(
  File "/usr/lib/python3.8/traceback.py", line 340, in extract
    if limit >= 0:
TypeError: '>=' not supported between instances of 'tuple' and 'int'
```