### PR TITLE
Added another Zyxel default variant

### DIFF
--- a/routersploit/modules/creds/routers/zyxel/ftp_default_creds.py
+++ b/routersploit/modules/creds/routers/zyxel/ftp_default_creds.py
@@ -19,4 +19,4 @@ class Exploit(FTPDefault):
     port = OptPort(21, "Target FTP port")
 
     threads = OptInteger(1, "Number of threads")
-    defaults = OptWordlist("admin:admin,admin:1234,admin:user", "User:Pass or file with default credentials (file://)")
+    defaults = OptWordlist("admin:admin,admin:1234,admin:user,admin:Zyxel*2012*", "User:Pass or file with default credentials (file://)")

--- a/routersploit/modules/creds/routers/zyxel/ssh_default_creds.py
+++ b/routersploit/modules/creds/routers/zyxel/ssh_default_creds.py
@@ -19,4 +19,4 @@ class Exploit(SSHDefault):
     port = OptPort(22, "Target SSH port")
 
     threads = OptInteger(1, "Number of threads")
-    defaults = OptWordlist("admin:admin,admin:1234,admin:user", "User:Pass or file with default credentials (file://)")
+    defaults = OptWordlist("admin:admin,admin:1234,admin:user,admin:Zyxel*2012*", "User:Pass or file with default credentials (file://)")

--- a/routersploit/modules/creds/routers/zyxel/telnet_default_creds.py
+++ b/routersploit/modules/creds/routers/zyxel/telnet_default_creds.py
@@ -19,4 +19,4 @@ class Exploit(TelnetDefault):
     port = OptPort(23, "Target Telnet port")
 
     threads = OptInteger(1, "Number of threads")
-    defaults = OptWordlist("admin:admin,admin:1234,admin:user", "User:Pass or file with default credentials (file://)")
+    defaults = OptWordlist("admin:admin,admin:1234,admin:user,admin:Zyxel*2012*", "User:Pass or file with default credentials (file://)")

--- a/routersploit/resources/wordlists/defaults.txt
+++ b/routersploit/resources/wordlists/defaults.txt
@@ -252,6 +252,7 @@ admin:visual
 admin:w2402
 admin:xad$l#12
 admin:zhone
+admin:Zyxel*2012*
 admin:zhongxing
 admin:zoomadsl
 administrator:1234

--- a/routersploit/resources/wordlists/passwords.txt
+++ b/routersploit/resources/wordlists/passwords.txt
@@ -713,3 +713,4 @@ zoomadsl
 zsun1188
 zxcvbnm
 zyad1234
+Zyxel*2012*

--- a/tests/creds/routers/zyxel/test_ftp_default_creds.py
+++ b/tests/creds/routers/zyxel/test_ftp_default_creds.py
@@ -9,7 +9,7 @@ def test_check_success(generic_target):
     assert exploit.target == ""
     assert exploit.port == 21
     assert exploit.threads == 1
-    assert exploit.defaults == ["admin:admin", "admin:1234", "admin:user"]
+    assert exploit.defaults == ["admin:admin", "admin:1234", "admin:user","admin:Zyxel*2012*"]
     assert exploit.stop_on_success is True
     assert exploit.verbosity is True
 

--- a/tests/creds/routers/zyxel/test_ssh_default_creds.py
+++ b/tests/creds/routers/zyxel/test_ssh_default_creds.py
@@ -9,7 +9,7 @@ def test_check_success(generic_target):
     assert exploit.target == ""
     assert exploit.port == 22
     assert exploit.threads == 1
-    assert exploit.defaults == ["admin:admin", "admin:1234", "admin:user"]
+    assert exploit.defaults == ["admin:admin", "admin:1234", "admin:user","admin:Zyxel*2012*"]
     assert exploit.stop_on_success is True
     assert exploit.verbosity is True
 

--- a/tests/creds/routers/zyxel/test_telnet_default_creds.py
+++ b/tests/creds/routers/zyxel/test_telnet_default_creds.py
@@ -9,7 +9,7 @@ def test_check_success(generic_target):
     assert exploit.target == ""
     assert exploit.port == 23
     assert exploit.threads == 1
-    assert exploit.defaults == ["admin:admin", "admin:1234", "admin:user"]
+    assert exploit.defaults == ["admin:admin", "admin:1234", "admin:user","admin:Zyxel*2012*"]
     assert exploit.stop_on_success is True
     assert exploit.verbosity is True
 


### PR DESCRIPTION
## Status
READY

## Description
Added another default variant I have observed on Zyxel routers

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use scanners/routers/router
 3. `set target 192.168.X.1`
 4. `run`
 5. ...

## Checklist
- [x] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [x] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
