### PR TITLE
Resolved issue with exploit (#766)

### DIFF
--- a/routersploit/libs/apiros/apiros_client.py
+++ b/routersploit/libs/apiros/apiros_client.py
@@ -145,7 +145,7 @@ class ApiRosClient(object):
         ret = ''
         while len(ret) < length:
             s = self.sk.recv(length - len(ret))
-            if s == '':
+            if s is None or s == '':
                 raise RuntimeError("connection closed by remote end")
 
             ret += s.decode('UTF-8', 'replace')

--- a/routersploit/modules/creds/routers/mikrotik/api_ros_default_creds.py
+++ b/routersploit/modules/creds/routers/mikrotik/api_ros_default_creds.py
@@ -51,7 +51,7 @@ class Exploit(TCPClient):
 
                 tcp_client = self.tcp_create()
                 tcp_sock = tcp_client.connect()
-                apiros = ApiRosClient(tcp_sock)
+                apiros = ApiRosClient(tcp_client)
 
                 output = apiros.login(username, password)
 
@@ -65,6 +65,9 @@ class Exploit(TCPClient):
                     print_error("Authentication Failed - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
 
                 tcp_client.close()
+            
+            except RuntimeError:
+                print_error("Connection closed by remote end")
 
             except StopIteration:
                 break


### PR DESCRIPTION
## Status
READY

## Description
I have updated target_function within api_ros_default_creds.py in that I have replaced tcp_sock with tcp_client as it was returning a boolean value instead of tcp_client object because of which exception in Issue request ($766) happened. On fixing this there was another issue at library apiros_client.py where readstr function was checking for an empty string however the sk.recv method was returning None instead so added a check for None value.

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. ` use creds/routers/mikrotik/api_ros_default_creds`
 3. `set target 192.168.1.1`
 4. `run`

## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
