### PR TITLE
Fix non iterable

### DIFF
--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -39,10 +39,7 @@ import readline
 
 
 def is_libedit():
-    try:
-        return "libedit" in readline.__doc__
-    except TypeError:
-        return False
+    return isinstance(readline.__doc__, str) and "libedit" in readline.__doc__
 
 class BaseInterpreter(object):
     history_file = os.path.expanduser("~/.history")

--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -39,8 +39,10 @@ import readline
 
 
 def is_libedit():
-    return "libedit" in readline.__doc__
-
+    try:
+        return "libedit" in readline.__doc__
+    except TypeError:
+        return False
 
 class BaseInterpreter(object):
     history_file = os.path.expanduser("~/.history")


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes/prevents a 'TypeError: argument of type 'NoneType' is not iterable' error.
I defaulted to returning False when the initial return failed.

## Original error
```
Traceback (most recent call last):
  File "C:\Users\***\source\routersploit\rsf.py", line 29, in <module>
    routersploit(sys.argv)
  File "C:\Users\***\source\routersploit\rsf.py", line 21, in routersploit
    rsf = RoutersploitInterpreter()
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\***\source\routersploit\routersploit\interpreter.py", line 214, in __init__
    super(RoutersploitInterpreter, self).__init__()
  File "C:\Users\***\source\routersploit\routersploit\interpreter.py", line 54, in __init__
    self.setup()
  File "C:\Users\***\source\routersploit\routersploit\interpreter.py", line 78, in setup
    if is_libedit():
       ^^^^^^^^^^^^
  File "C:\Users\***\source\routersploit\routersploit\interpreter.py", line 43, in is_libedit
    return "libedit" in readline.__doc__
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py` (On windows this was enough to trip the bug.)
 2. Continue using the script (If you made it to this point the fix works.)

## Checklist
- [x] Write module/feature
