### PR TITLE
Drop the dependency on python-future

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ It consists of various modules that aid penetration testing operations:
 ## Requirements
 
 Required:
-* future
 * requests
 * paramiko
 * pysnmp

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-future
 requests==2.31.0
 paramiko
 pysnmp==4.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-future
 requests==2.31.0
 paramiko
 pysnmp==4.4.6

--- a/routersploit/core/exploit/exploit.py
+++ b/routersploit/core/exploit/exploit.py
@@ -1,7 +1,6 @@
 import os
 import threading
 import time
-from future.utils import with_metaclass, iteritems
 from itertools import chain
 from functools import wraps
 
@@ -40,9 +39,9 @@ class ExploitOptionsAggregator(type):
         except AttributeError:
             attrs["exploit_attributes"] = {}
         else:
-            attrs["exploit_attributes"] = {k: v for d in base_exploit_attributes for k, v in iteritems(d)}
+            attrs["exploit_attributes"] = {k: v for d in base_exploit_attributes for k, v in d.items()}
 
-        for key, value in iteritems(attrs.copy()):
+        for key, value in attrs.copy().items():
             if isinstance(value, Option):
                 value.label = key
                 attrs["exploit_attributes"].update({key: [value.display_value, value.description, value.advanced]})
@@ -55,7 +54,7 @@ class ExploitOptionsAggregator(type):
         return super(ExploitOptionsAggregator, cls).__new__(cls, name, bases, attrs)
 
 
-class BaseExploit(with_metaclass(ExploitOptionsAggregator, object)):
+class BaseExploit(metaclass=ExploitOptionsAggregator):
     @property
     def options(self):
         """ Returns list of options that user can set.

--- a/routersploit/core/exploit/payloads.py
+++ b/routersploit/core/exploit/payloads.py
@@ -1,7 +1,6 @@
 import importlib
 from collections import namedtuple
 from struct import pack
-from future.utils import with_metaclass
 
 from routersploit.core.exploit.exploit import (
     BaseExploit,
@@ -90,13 +89,13 @@ ARCH_ELF_HEADERS = {
 }
 
 
-class ReverseTCPPayloadMixin(with_metaclass(ExploitOptionsAggregator, object)):
+class ReverseTCPPayloadMixin(metaclass=ExploitOptionsAggregator):
     handler = PayloadHandlers.REVERSE_TCP
     lhost = OptIP('', 'Connect-back IP address')
     lport = OptPort(5555, 'Connect-back TCP Port')
 
 
-class BindTCPPayloadMixin(with_metaclass(ExploitOptionsAggregator, object)):
+class BindTCPPayloadMixin(metaclass=ExploitOptionsAggregator):
     handler = PayloadHandlers.BIND_TCP
     rport = OptPort(5555, 'Bind Port')
 

--- a/routersploit/core/exploit/printer.py
+++ b/routersploit/core/exploit/printer.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 import threading
 import sys
 import collections

--- a/routersploit/interpreter.py
+++ b/routersploit/interpreter.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import atexit
 import itertools
 import pkgutil
@@ -8,8 +6,6 @@ import sys
 import getopt
 import traceback
 from collections import Counter
-
-from future.builtins import input
 
 from routersploit.core.exploit.exceptions import RoutersploitException
 from routersploit.core.exploit.utils import (

--- a/rsf.py
+++ b/rsf.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
 import logging.handlers
 import sys
 if sys.version_info.major < 3:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     scripts=('rsf.py',),
     entry_points={},
     install_requires=[
-        "future",
         "requests",
         "paramiko",
         "pysnmp",


### PR DESCRIPTION
## Status
**READY**

## Description
Python version 2 is now EOL for 11 years, so it should be safe to drop support for it. As python-future is not compatible with python 3.13 it is also desirable to actively patch it out.
