### PR TITLE
Updated 2x vuln checks to not trigger false positives on devices that…

### DIFF
--- a/routersploit/modules/exploits/cameras/geuterbruck/efd_2250.py
+++ b/routersploit/modules/exploits/cameras/geuterbruck/efd_2250.py
@@ -41,6 +41,11 @@ class Exploit(HTTPClient):
 
     def check(self) -> bool:
         response = self.http_request(method='GET', path="/uapi-cgi/viewer/simple_loglistjs.cgi")
+
+        # Lots of devices are redirecting. This triggers a false positive.
+        if response.status_code == 307:
+            return False
+
         if response:
             return True
         return False

--- a/routersploit/modules/exploits/cameras/multi/cctv_dvr_rce.py
+++ b/routersploit/modules/exploits/cameras/multi/cctv_dvr_rce.py
@@ -153,6 +153,11 @@ class Exploit(HTTPClient):
             method="GET",
             path="/language/Swedish${IFS}&&echo${IFS}1>test&&tar${IFS}/string.js"
         )
+
+        # Lots of devices are redirecting. This triggers a false positive.
+        if response.status_code == 307:
+            return False
+
         if response is None:
             return False
         # Read the file.


### PR DESCRIPTION
… are redirecting all GET requests.

## Status
**READY**

## Verification
Before
```
(pyenv) machinehum@Walkers-MBP routersploit % python rsf.py
 ______            _            _____       _       _ _
 | ___ \          | |          /  ___|     | |     (_) |
 | |_/ /___  _   _| |_ ___ _ __\ `--. _ __ | | ___  _| |_
 |    // _ \| | | | __/ _ \ '__|`--. \ '_ \| |/ _ \| | __|
 | |\ \ (_) | |_| | ||  __/ |  /\__/ / |_) | | (_) | | |_
 \_| \_\___/ \__,_|\__\___|_|  \____/| .__/|_|\___/|_|\__|
                                     | |
       Exploitation Framework for    |_|    by Threat9
            Embedded Devices

 Codename   : I Knew You Were Trouble
 Version    : 3.4.7
 Homepage   : https://www.threat9.com - @threatnine

 Exploits: 143 Scanners: 4 Creds: 171 Generic: 4 Payloads: 32 Encoders: 6

rsf > set target 192.168.1.1 
[-] You have to activate any module with 'use' command.
rsf > 
rsf > use scanners/autopwn
rsf (AutoPwn) > set target 192.168.1.1 
[+] target => 192.168.1.1
rsf (AutoPwn) > run
[*] Running module scanners/autopwn...

[*] 192.168.1.1 Starting vulnerablity check...
[*] 192.168.1.1:80 http exploits/routers/billion/billion_5200w_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/billion/billion_7700nr4_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/comtrend/ct_5361t_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/thomson/twg850_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/generic/shellshock is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/dlink/dsl_2740r_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_825_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_645_815_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_300_320_615_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsl_2750b_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_8xx_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/multi_hnap_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_655_866_652_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_300_320_600_615_info_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/dlink/dsl_2730b_2780b_526b_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_300_600_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsl_2730_2750_path_traversal is not vulnerable
[*] 192.168.1.1:1900 custom/udp exploits/routers/dlink/dir_815_850l_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dvg_n5402sp_path_traversal is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/dlink/dsl_2640b_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_645_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_850l_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/multi_hedwig_cgi_exec is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dgs_1510_add_user is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsp_w110_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dwr_932_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dns_320l_327l_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dcs_930l_auth_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dwl_3200ap_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsl_2750b_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/e5331_mifi_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/hg866_password_change is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/hg532_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/hg530_hg520b_password_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/asus/asuswrt_lan_rce Could not be verified
[-] 192.168.1.1:80 http exploits/generic/heartbleed is not vulnerable
[-] 192.168.1.1:39889 custom/udp exploits/routers/dlink/dwr_932b_backdoor is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/asus/rt_n16_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zte/zxv10_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zte/zxhn_h108n_wifi_password_disclosure is not vulnerable
[-] 192.168.1.1:1900 custom/udp exploits/routers/dlink/dir_300_645_815_upnp_rce is not vulnerable
[-] 192.168.1.1:43690 custom/udp exploits/routers/huawei/hg520_info_disclosure is not vulnerable
[-] 192.168.1.1:21 ftp exploits/routers/technicolor/tg784_authbypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/technicolor/dwg855_authbypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zte/f460_f660_backdoor is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/technicolor/tc7200_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/technicolor/tc7200_password_disclosure_v2 is not vulnerable
[-] 192.168.1.1:22 snmp exploits/routers/thomson/twg849_info_disclosure is not vulnerable
[-] 192.168.1.1:32764 custom/tcp exploits/routers/multi/tcp_32764_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/multi/gpon_home_gateway_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/multi/misfortune_cookie is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/multi/rom0 is not vulnerable
[-] 192.168.1.1:32764 custom/tcp exploits/routers/multi/tcp_32764_rce is not vulnerable
[-] 192.168.1.1:22 ssh exploits/routers/mikrotik/routeros_jailbreak is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/g_n150_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/play_max_prce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/g_plus_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/n750_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/n150_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/asmax/ar_1004g_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/asmax/ar_804_gu_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/movistar/adsl_router_bhs_rta_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/ubiquiti/airos_6_x is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/unified_multi_path_traversal is not vulnerable
[-] 192.168.1.1:69 custom/udp exploits/routers/cisco/ucm_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/rv320_command_injection is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/cisco/secure_acs_bypass Could not be verified
[-] 192.168.1.1:80 http exploits/routers/cisco/ucs_manager_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/dpc2420_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/firepower_management60_path_traversal is not vulnerable
[*] 192.168.1.1:23 custom/tcp exploits/routers/cisco/catalyst_2960_rocem Could not be verified
[-] 192.168.1.1:80 http exploits/routers/ipfire/ipfire_shellshock is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/shuttle/915wm_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/ipfire/ipfire_oinkcode_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/ipfire/ipfire_proxy_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/2wire/4011g_5012nv_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/2wire/gateway_auth_bypass is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/netgear/dgn2200_dnslookup_cgi_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/netgear/rax30_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/jnr1010_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/multi_password_disclosure-2017-5521 is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/dgn2200_ping_cgi_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/n300_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/prosafe_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/wnr500_612v3_jnr1010_2010_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/r7000_r6400_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/archer_c2_c20i_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/wdr740nd_wdr740n_backdoor is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/multi_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netsys/multi_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/wdr842nd_wdr842n_configure_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/wdr740nd_wdr740n_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/archer_c9_admin_password_reset is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/d1000_wifi_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/p660hn_t_v1_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/d1000_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/p660hn_t_v2_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/lg/nas_3718 is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/bhu/bhu_urouter_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/3com/ap8760_password_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/3com/officeconnect_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/3com/imc_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/3com/officeconnect_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/3com/imc_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/ios_http_authorization_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/1500_2500_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/wap54gv3_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/eseries_themoon_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/smartwifi_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/wrt100_110_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/honeywell/hicc_1100pt_password_disclosure is not vulnerable
[-] 192.168.1.1:9999 custom/udp exploits/routers/asus/infosvr_backdoor_rce is not vulnerable
[-] 192.168.1.1:53413 custom/udp exploits/routers/netcore/udp_53413_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/beward/n100_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/dlink/dcs_930l_932l_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/jovision/jovision_credentials_disclosure is not vulnerable
[+] 192.168.1.1:80 http exploits/cameras/multi/cctv_dvr_rce is vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/jvc_vanderbilt_honeywell_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/P2P_wificam_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/dvr_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/P2P_wificam_credential_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/netwave_ip_camera_information_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/siemens/cvms2025_credentials_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/avigilon/videoiq_camera_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/acti/acm_5611_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/cisco/video_surv_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/brickcom/users_cgi_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/brickcom/corp_network_cameras_conf_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/mvpower/dvr_jaws_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/xiongmai/uc_httpd_path_traversal is not vulnerable
[+] 192.168.1.1:80 http exploits/cameras/geuterbruck/efd_2250 is vulnerable
[-] 192.168.1.1:80 http exploits/misc/wepresent/wipg1000_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/asus/b1m_projector_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/watchguard/xcs_9_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/miele/pg8528_path_traversal is not vulnerable
[-] 192.168.1.1:8291 custom/tcp exploits/routers/mikrotik/winbox_auth_bypass_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/firepower_management60_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/zywall_usg_extract_hashes is not vulnerable
[-] 192.168.1.1:23 telnet exploits/cameras/grandstream/gxv3611hd_ip_camera_backdoor is not vulnerable
[-] 192.168.1.1:23 telnet exploits/cameras/grandstream/gxv3611hd_ip_camera_sqli is not vulnerable
[-] 192.168.1.1:22 ssh exploits/generic/ssh_auth_keys is not vulnerable
[-] 192.168.1.1:22 ssh exploits/routers/fortinet/fortigate_os_backdoor is not vulnerable
[*] Elapsed time: 113.4300 seconds

[*] 192.168.1.1 Starting default credentials check...
[-] 192.168.1.1:80 http creds/routers/pfsense/webinterface_http_form_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/routers/asmax/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/basler/webinterface_http_form_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/acti/webinterface_http_form_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/generic/http_basic_digest_default is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/brickcom/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/axis/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/canon/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:21 ftp creds/generic/ftp_default is not vulnerable
[-] 192.168.1.1:22 ssh creds/generic/ssh_default is not vulnerable
[-] 192.168.1.1:23 telnet creds/generic/telnet_default is not vulnerable
[*] Elapsed time: 30.0000 seconds

[*] 192.168.1.1 Could not verify exploitability:
 - 192.168.1.1:80 http exploits/routers/billion/billion_5200w_rce
 - 192.168.1.1:80 http exploits/routers/dlink/dsl_2740r_dns_change
 - 192.168.1.1:80 http exploits/routers/dlink/dsl_2730b_2780b_526b_dns_change
 - 192.168.1.1:1900 custom/udp exploits/routers/dlink/dir_815_850l_rce
 - 192.168.1.1:80 http exploits/routers/dlink/dsl_2640b_dns_change
 - 192.168.1.1:80 http exploits/routers/asus/asuswrt_lan_rce
 - 192.168.1.1:80 http exploits/routers/cisco/secure_acs_bypass
 - 192.168.1.1:23 custom/tcp exploits/routers/cisco/catalyst_2960_rocem
 - 192.168.1.1:80 http exploits/routers/shuttle/915wm_dns_change
 - 192.168.1.1:80 http exploits/routers/netgear/dgn2200_dnslookup_cgi_rce
 - 192.168.1.1:80 http exploits/routers/3com/officeconnect_rce

[+] 192.168.1.1 Device is vulnerable:

   Target          Port     Service     Exploit                                   
   ------          ----     -------     -------                                   
   192.168.1.1     80       http        exploits/cameras/multi/cctv_dvr_rce       
   192.168.1.1     80       http        exploits/cameras/geuterbruck/efd_2250     
```

After
```
(pyenv) machinehum@Walkers-MBP routersploit % python rsf.py
 ______            _            _____       _       _ _
 | ___ \          | |          /  ___|     | |     (_) |
 | |_/ /___  _   _| |_ ___ _ __\ `--. _ __ | | ___  _| |_
 |    // _ \| | | | __/ _ \ '__|`--. \ '_ \| |/ _ \| | __|
 | |\ \ (_) | |_| | ||  __/ |  /\__/ / |_) | | (_) | | |_
 \_| \_\___/ \__,_|\__\___|_|  \____/| .__/|_|\___/|_|\__|
                                     | |
       Exploitation Framework for    |_|    by Threat9
            Embedded Devices

 Codename   : I Knew You Were Trouble
 Version    : 3.4.7
 Homepage   : https://www.threat9.com - @threatnine

 Exploits: 143 Scanners: 4 Creds: 171 Generic: 4 Payloads: 32 Encoders: 6

rsf > set scanners/autopwn
[-] You have to activate any module with 'use' command.
rsf > use scanners/autopwn
rsf (AutoPwn) > set target 192.168.1.1 
[+] target => 192.168.1.1
rsf (AutoPwn) > run 
[*] Running module scanners/autopwn...

[*] 192.168.1.1 Starting vulnerablity check...
[*] 192.168.1.1:80 http exploits/routers/billion/billion_5200w_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/thomson/twg850_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/billion/billion_7700nr4_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/comtrend/ct_5361t_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_645_815_rce is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/dlink/dsl_2740r_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/generic/shellshock is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_825_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsl_2750b_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_8xx_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_300_320_615_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/multi_hnap_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_655_866_652_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_300_320_600_615_info_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/dlink/dsl_2730b_2780b_526b_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dvg_n5402sp_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_300_600_rce is not vulnerable
[*] 192.168.1.1:1900 custom/udp exploits/routers/dlink/dir_815_850l_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dsl_2730_2750_path_traversal is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/dlink/dsl_2640b_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_850l_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dir_645_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/multi_hedwig_cgi_exec is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dgs_1510_add_user is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsp_w110_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dwr_932_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dns_320l_327l_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dcs_930l_auth_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dwl_3200ap_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/dlink/dsl_2750b_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/e5331_mifi_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/hg866_password_change is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/hg532_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/huawei/hg530_hg520b_password_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/asus/asuswrt_lan_rce Could not be verified
[-] 192.168.1.1:80 http exploits/generic/heartbleed is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/asus/rt_n16_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zte/zxhn_h108n_wifi_password_disclosure is not vulnerable
[-] 192.168.1.1:39889 custom/udp exploits/routers/dlink/dwr_932b_backdoor is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zte/zxv10_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zte/f460_f660_backdoor is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/technicolor/dwg855_authbypass is not vulnerable
[-] 192.168.1.1:21 ftp exploits/routers/technicolor/tg784_authbypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/technicolor/tc7200_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/technicolor/tc7200_password_disclosure_v2 is not vulnerable
[-] 192.168.1.1:1900 custom/udp exploits/routers/dlink/dir_300_645_815_upnp_rce is not vulnerable
[-] 192.168.1.1:43690 custom/udp exploits/routers/huawei/hg520_info_disclosure is not vulnerable
[-] 192.168.1.1:22 snmp exploits/routers/thomson/twg849_info_disclosure is not vulnerable
[-] 192.168.1.1:32764 custom/tcp exploits/routers/multi/tcp_32764_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/multi/gpon_home_gateway_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/multi/misfortune_cookie is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/multi/rom0 is not vulnerable
[-] 192.168.1.1:32764 custom/tcp exploits/routers/multi/tcp_32764_rce is not vulnerable
[-] 192.168.1.1:22 ssh exploits/routers/mikrotik/routeros_jailbreak is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/g_n150_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/play_max_prce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/g_plus_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/n750_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/belkin/n150_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/asmax/ar_1004g_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/asmax/ar_804_gu_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/movistar/adsl_router_bhs_rta_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/ubiquiti/airos_6_x is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/unified_multi_path_traversal is not vulnerable
[-] 192.168.1.1:69 custom/udp exploits/routers/cisco/ucm_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/rv320_command_injection is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/cisco/secure_acs_bypass Could not be verified
[-] 192.168.1.1:80 http exploits/routers/cisco/ucs_manager_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/ipfire/ipfire_shellshock is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/ipfire/ipfire_oinkcode_rce is not vulnerable
[*] 192.168.1.1:23 custom/tcp exploits/routers/cisco/catalyst_2960_rocem Could not be verified
[-] 192.168.1.1:80 http exploits/routers/cisco/dpc2420_info_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/shuttle/915wm_dns_change Could not be verified
[-] 192.168.1.1:80 http exploits/routers/cisco/firepower_management60_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/2wire/4011g_5012nv_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/2wire/gateway_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/rax30_rce is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/netgear/dgn2200_dnslookup_cgi_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/netgear/jnr1010_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/dgn2200_ping_cgi_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/multi_password_disclosure-2017-5521 is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/n300_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/prosafe_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/ipfire/ipfire_proxy_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/r7000_r6400_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/wnr500_612v3_jnr1010_2010_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netgear/multi_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/archer_c2_c20i_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/wdr740nd_wdr740n_backdoor is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/wdr842nd_wdr842n_configure_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/netsys/multi_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/wdr740nd_wdr740n_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/tplink/archer_c9_admin_password_reset is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/d1000_wifi_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/p660hn_t_v1_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/d1000_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/p660hn_t_v2_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/lg/nas_3718 is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/bhu/bhu_urouter_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/3com/ap8760_password_disclosure is not vulnerable
[*] 192.168.1.1:80 http exploits/routers/3com/officeconnect_rce Could not be verified
[-] 192.168.1.1:80 http exploits/routers/3com/imc_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/3com/officeconnect_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/3com/imc_info_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/ios_http_authorization_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/1500_2500_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/wap54gv3_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/eseries_themoon_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/smartwifi_password_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/linksys/wrt100_110_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/honeywell/hicc_1100pt_password_disclosure is not vulnerable
[-] 192.168.1.1:9999 custom/udp exploits/routers/asus/infosvr_backdoor_rce is not vulnerable
[-] 192.168.1.1:53413 custom/udp exploits/routers/netcore/udp_53413_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/beward/n100_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/dlink/dcs_930l_932l_auth_bypass is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/jovision/jovision_credentials_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/cctv_dvr_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/jvc_vanderbilt_honeywell_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/P2P_wificam_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/dvr_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/P2P_wificam_credential_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/multi/netwave_ip_camera_information_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/siemens/cvms2025_credentials_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/avigilon/videoiq_camera_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/acti/acm_5611_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/cisco/video_surv_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/brickcom/users_cgi_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/brickcom/corp_network_cameras_conf_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/mvpower/dvr_jaws_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/xiongmai/uc_httpd_path_traversal is not vulnerable
[-] 192.168.1.1:80 http exploits/cameras/geuterbruck/efd_2250 is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/wepresent/wipg1000_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/asus/b1m_projector_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/watchguard/xcs_9_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/misc/miele/pg8528_path_traversal is not vulnerable
[-] 192.168.1.1:8291 custom/tcp exploits/routers/mikrotik/winbox_auth_bypass_creds_disclosure is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/cisco/firepower_management60_rce is not vulnerable
[-] 192.168.1.1:80 http exploits/routers/zyxel/zywall_usg_extract_hashes is not vulnerable
[-] 192.168.1.1:23 telnet exploits/cameras/grandstream/gxv3611hd_ip_camera_backdoor is not vulnerable
[-] 192.168.1.1:23 telnet exploits/cameras/grandstream/gxv3611hd_ip_camera_sqli is not vulnerable
[-] 192.168.1.1:22 ssh exploits/generic/ssh_auth_keys is not vulnerable
[-] 192.168.1.1:22 ssh exploits/routers/fortinet/fortigate_os_backdoor is not vulnerable
[*] Elapsed time: 113.2400 seconds

[*] 192.168.1.1 Starting default credentials check...
[-] 192.168.1.1:80 http creds/routers/pfsense/webinterface_http_form_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/generic/http_basic_digest_default is not vulnerable
[-] 192.168.1.1:80 http creds/routers/asmax/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/acti/webinterface_http_form_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/basler/webinterface_http_form_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/brickcom/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/canon/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:80 http creds/cameras/axis/webinterface_http_auth_default_creds is not vulnerable
[-] 192.168.1.1:22 ssh creds/generic/ssh_default is not vulnerable
[-] 192.168.1.1:21 ftp creds/generic/ftp_default is not vulnerable
[-] 192.168.1.1:23 telnet creds/generic/telnet_default is not vulnerable
[*] Elapsed time: 30.0000 seconds

[*] 192.168.1.1 Could not verify exploitability:
 - 192.168.1.1:80 http exploits/routers/billion/billion_5200w_rce
 - 192.168.1.1:80 http exploits/routers/dlink/dsl_2740r_dns_change
 - 192.168.1.1:80 http exploits/routers/dlink/dsl_2730b_2780b_526b_dns_change
 - 192.168.1.1:1900 custom/udp exploits/routers/dlink/dir_815_850l_rce
 - 192.168.1.1:80 http exploits/routers/dlink/dsl_2640b_dns_change
 - 192.168.1.1:80 http exploits/routers/asus/asuswrt_lan_rce
 - 192.168.1.1:80 http exploits/routers/cisco/secure_acs_bypass
 - 192.168.1.1:23 custom/tcp exploits/routers/cisco/catalyst_2960_rocem
 - 192.168.1.1:80 http exploits/routers/shuttle/915wm_dns_change
 - 192.168.1.1:80 http exploits/routers/netgear/dgn2200_dnslookup_cgi_rce
 - 192.168.1.1:80 http exploits/routers/3com/officeconnect_rce

[-] 192.168.1.1 Could not confirm any vulnerablity

[-] 192.168.1.1 Could not find default credentials
```
## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
