### PR TITLE
Add telnetlib3 to development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-forked
 pytest-xdist
 flake8
 git+git://github.com/threat9/threat9-test-bed
+telnetlib3


### PR DESCRIPTION
# Fix: `ModuleNotFoundError: No module named 'telnetlib'` in RouterSploit

## ❌ Error Encountered

While running RouterSploit using Python 3.13, the following error occurred:

```bash
python3 rsf.py

## Status
**READY/IN DEVELOPMENT/HOLD**

`Traceback (most recent call last):
  File "/home/h9873/routersploit/rsf.py", line 9, in <module>
    from routersploit.interpreter import RoutersploitInterpreter
  File "/home/h9873/routersploit/routersploit/interpreter.py", line 12, in <module>
    from routersploit.core.exploit.exceptions import RoutersploitException
  File "/home/h9873/routersploit/routersploit/core/exploit/__init__.py", line 28, in <module>
    from routersploit.core.exploit.shell import shell
  File "/home/h9873/routersploit/routersploit/core/exploit/shell.py", line 2, in <module>
    import telnetlib
ModuleNotFoundError: No module named 'telnetlib'
`

`pip install telnetlib3
`

## Description
Describe what is changed by your Pull Request. If this PR is related to the open issue (bug/feature/new module) please attach issue number.

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/dlink/dsl_2750b_rce`
 3. `set target 192.168.1.1`
 4. `run`
 5. ...

## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
