### PR TITLE
fix: replace bare except Exception with specific ftplib exceptions

### DIFF
--- a/routersploit/core/ftp/ftp_client.py
+++ b/routersploit/core/ftp/ftp_client.py
@@ -46,7 +46,7 @@ class FTPCli:
             try:
                 self.ftp_client.connect(self.ftp_target, self.ftp_port, timeout=FTP_TIMEOUT)
                 return True
-            except Exception as err:
+            except (ftplib.all_errors, OSError) as err:
                 print_error(self.peer, "FTP Error while connecting to the server", err, verbose=self.verbosity)
 
             self.ftp_client.close()
@@ -65,8 +65,8 @@ class FTPCli:
             self.ftp_client.login(username, password)
             print_success(self.peer, "FTP Authentication Successful - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
             return True
-        except Exception:
-            print_error(self.peer, "FTP Authentication Failed - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
+        except ftplib.all_errors as err:
+            print_error(self.peer, "FTP Authentication Failed - Username: '{}' Password: '{}'".format(username, password), err, verbose=self.verbosity)
 
         self.ftp_client.close()
         return False
@@ -94,7 +94,7 @@ class FTPCli:
             fp_content = io.BytesIO()
             self.ftp_client.retrbinary("RETR {}".format(remote_file), fp_content.write)
             return fp_content.getvalue()
-        except Exception as err:
+        except (ftplib.all_errors, OSError) as err:
             print_error(self.peer, "FTP Error while retrieving content", err, verbose=self.verbosity)
 
         return None
@@ -108,7 +108,7 @@ class FTPCli:
         try:
             self.ftp_client.close()
             return True
-        except Exception as err:
+        except (ftplib.all_errors, OSError) as err:
             print_error(self.peer, "FTP Error while closing connection", err, verbose=self.verbosity)
 
         return False


### PR DESCRIPTION
## Summary

Replaced bare except Exception clauses with specific ftplib.all_errors exceptions in the FTP client.

## Why

Using broad except Exception clauses can mask errors and make debugging difficult. The ftplib.all_errors tuple is the appropriate exception type for FTP operations.

## Changes

- connect(): Changed to except ftplib.all_errors, OSError
- login(): Changed to except ftplib.all_errors, added error logging
- get_content(): Changed to except ftplib.all_errors, OSError
- close(): Changed to except ftplib.all_errors, OSError

Affects: routersploit/core/ftp/ftp_client.py