### PR TITLE
Replace bare except clauses with specific exception types

### DIFF
--- a/routersploit/core/bluetooth/btle/btle_device.py
+++ b/routersploit/core/bluetooth/btle/btle_device.py
@@ -2,7 +2,8 @@ import struct
 from bluepy.btle import (
     Peripheral,
     ScanEntry,
-    AssignedNumbers
+    AssignedNumbers,
+    BTLEException
 )
 from routersploit.core.exploit.printer import (
     print_table,
@@ -96,12 +97,12 @@ class Device(ScanEntry):
 
             return data
 
-        except Exception as err:
+        except BTLEException as err:
             print_error(err)
 
         try:
             dev.disconnect()
-        except Exception as err:
+        except BTLEException as err:
             print_error(err)
 
         return None
@@ -135,7 +136,7 @@ class Device(ScanEntry):
                     try:
                         char.write(data, wwrflag)
                         print_success("Data sent")
-                    except Exception as err:
+                    except BTLEException as err:
                         print_error("Error: {}".format(err))
 
                 else:
@@ -143,12 +144,12 @@ class Device(ScanEntry):
 
             dev.disconnect()
 
-        except Exception as err:
+        except BTLEException as err:
             print_error(err)
 
         try:
             dev.disconnect()
-        except Exception:
+        except BTLEException:
             pass
 
         return None
@@ -220,10 +221,10 @@ class Device(ScanEntry):
                 else:
                     try:
                         string = color_blue(repr(data.decode("utf-8")))
-                    except Exception:
+                    except UnicodeDecodeError:
                         string = repr(data)
 
-            except Exception:
+            except BTLEException:
                 pass
 
         return string
@@ -387,7 +388,7 @@ class Device(ScanEntry):
 
             if code in appearance.keys():
                 return color_green(appearance[code])
-        except Exception:
+        except (struct.error, TypeError):
             pass
 
         return repr(data)

--- a/routersploit/core/exploit/shell.py
+++ b/routersploit/core/exploit/shell.py
@@ -117,7 +117,7 @@ def shell(exploit, architecture="", method="", payloads=None, **params):
                         if option[0] == c[1]:
                             try:
                                 setattr(payload, c[1], c[2])
-                            except Exception:
+                            except (ValueError, TypeError, AttributeError):
                                 print_error("Invalid value for {}".format(c[1]))
                                 break
 

--- a/routersploit/core/ftp/ftp_client.py
+++ b/routersploit/core/ftp/ftp_client.py
@@ -46,7 +46,7 @@ class FTPCli:
             try:
                 self.ftp_client.connect(self.ftp_target, self.ftp_port, timeout=FTP_TIMEOUT)
                 return True
-            except Exception as err:
+            except (ftplib.error_temp, ftplib.error_perm, OSError) as err:
                 print_error(self.peer, "FTP Error while connecting to the server", err, verbose=self.verbosity)
 
             self.ftp_client.close()
@@ -65,7 +65,7 @@ class FTPCli:
             self.ftp_client.login(username, password)
             print_success(self.peer, "FTP Authentication Successful - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
             return True
-        except Exception:
+        except (ftplib.error_perm, ftplib.error_temp):
             print_error(self.peer, "FTP Authentication Failed - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
 
         self.ftp_client.close()
@@ -94,7 +94,7 @@ class FTPCli:
             fp_content = io.BytesIO()
             self.ftp_client.retrbinary("RETR {}".format(remote_file), fp_content.write)
             return fp_content.getvalue()
-        except Exception as err:
+        except (ftplib.error_temp, ftplib.error_perm, OSError) as err:
             print_error(self.peer, "FTP Error while retrieving content", err, verbose=self.verbosity)
 
         return None
@@ -108,7 +108,7 @@ class FTPCli:
         try:
             self.ftp_client.close()
             return True
-        except Exception as err:
+        except (ftplib.error_temp, OSError) as err:
             print_error(self.peer, "FTP Error while closing connection", err, verbose=self.verbosity)
 
         return False

--- a/routersploit/core/telnet/telnet_client.py
+++ b/routersploit/core/telnet/telnet_client.py
@@ -3,6 +3,8 @@ try:
 except ImportError:
     import telnetlib3 as telnetlib
 
+import socket
+
 from routersploit.core.exploit.exploit import Exploit
 from routersploit.core.exploit.exploit import Protocol
 from routersploit.core.exploit.option import OptBool
@@ -42,7 +44,7 @@ class TelnetCli:
         try:
             self.telnet_client = telnetlib.Telnet(self.telnet_target, self.telnet_port, timeout=TELNET_TIMEOUT)
             return True
-        except Exception as err:
+        except (socket.error, EOFError, OSError) as err:
             print_error(self.peer, "Telnet Error while connecting to the server", err, verbose=self.verbosity)
 
         return False
@@ -75,7 +77,7 @@ class TelnetCli:
                 else:
                     print_error(self.peer, "Telnet Authentication Failed - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
                     break
-            except Exception as err:
+            except (socket.error, EOFError, OSError) as err:
                 print_error(self.peer, "Telnet Error while authenticating to the server", err, verbose=self.verbosity)
 
         return False
@@ -92,7 +94,7 @@ class TelnetCli:
             self.telnet_client.close()
 
             return True
-        except Exception as err:
+        except (socket.error, EOFError, OSError) as err:
             print_error(self.peer, "Telnet Error while testing connection to the server", err, verbose=self.verbosity)
 
         return False
@@ -115,7 +117,7 @@ class TelnetCli:
         try:
             response = self.telnet_client.read_until(data, 5)
             return response
-        except Exception as err:
+        except (socket.error, EOFError, OSError) as err:
             print_error(self.peer, "Telnet Error while reading data from the server", err, verbose=self.verbosity)
 
         return None
@@ -130,7 +132,7 @@ class TelnetCli:
         try:
             self.telnet_client.write(data, 5)
             return True
-        except Exception as err:
+        except (socket.error, OSError) as err:
             print_error(self.peer, "Telnet Error while writing to the server", err, verbose=self.verbosity)
 
         return False
@@ -144,7 +146,7 @@ class TelnetCli:
         try:
             self.telnet_client.close()
             return True
-        except Exception as err:
+        except (socket.error, OSError) as err:
             print_error(self.peer, "Telnet Error while closing connection", err, verbose=self.verbosity)
 
         return False

--- a/routersploit/modules/exploits/cameras/multi/dvr_creds_disclosure.py
+++ b/routersploit/modules/exploits/cameras/multi/dvr_creds_disclosure.py
@@ -64,7 +64,7 @@ class Exploit(HTTPClient):
                 for data in json_data["list"]:
                     self.credentials.append((data["uid"], data["pwd"], data["role"]))
                 return True  # target is vulnerable
-            except Exception:
+            except (KeyError, ValueError, json.JSONDecodeError):
                 pass
 
         return False  # target is not vulnerable

--- a/routersploit/modules/exploits/cameras/multi/netwave_ip_camera_information_disclosure.py
+++ b/routersploit/modules/exploits/cameras/multi/netwave_ip_camera_information_disclosure.py
@@ -1,6 +1,8 @@
 from routersploit.core.exploit import *
 from routersploit.core.http.http_client import HTTPClient
 
+import requests
+
 
 class Exploit(HTTPClient):
     __info__ = {
@@ -59,7 +61,7 @@ class Exploit(HTTPClient):
                 for chunk in response.iter_content(chunk_size=100):
                     if "admin" in chunk:
                         print_success(chunk)
-            except Exception:
+            except (requests.exceptions.RequestException, TypeError):
                 print_error("Exploit failed - could not read /proc/kcore")
 
     @mute

--- a/routersploit/modules/exploits/routers/billion/billion_7700nr4_password_disclosure.py
+++ b/routersploit/modules/exploits/routers/billion/billion_7700nr4_password_disclosure.py
@@ -1,5 +1,6 @@
 import re
 import base64
+import binascii
 from routersploit.core.exploit import *
 from routersploit.core.http.http_client import HTTPClient
 
@@ -46,7 +47,7 @@ class Exploit(HTTPClient):
             try:
                 print_status("Trying to base64 decode")
                 password = base64.b64decode(res[0])
-            except Exception:
+            except (binascii.Error, ValueError):
                 print_error("Exploit failed - could not decode password")
                 return
 

--- a/routersploit/modules/exploits/routers/comtrend/ct_5361t_password_disclosure.py
+++ b/routersploit/modules/exploits/routers/comtrend/ct_5361t_password_disclosure.py
@@ -1,4 +1,5 @@
 import re
+import binascii
 from base64 import b64decode
 from routersploit.core.exploit import *
 from routersploit.core.http.http_client import HTTPClient
@@ -75,7 +76,7 @@ class Exploit(HTTPClient):
             if len(res):
                 try:
                     b64decode(res[0])  # checking if data is base64 encoded
-                except Exception:
+                except (binascii.Error, ValueError):
                     return False  # target is not vulnerable
             else:
                 return False  # target is not vulnerable

--- a/routersploit/modules/exploits/routers/dlink/dwl_3200ap_password_disclosure.py
+++ b/routersploit/modules/exploits/routers/dlink/dwl_3200ap_password_disclosure.py
@@ -1,4 +1,5 @@
 import re
+import requests
 from routersploit.core.exploit import *
 from routersploit.core.http.http_client import HTTPClient
 
@@ -60,7 +61,7 @@ class Exploit(HTTPClient):
                 print_error("Unable to retrieve cookie")
             else:
                 return tgt_cookie.group(1)
-        except Exception:
+        except requests.exceptions.RequestException:
             print_error("Unable to connect to target")
 
     def test_cookie(self, cookie_int):
@@ -80,5 +81,5 @@ class Exploit(HTTPClient):
                 pattern = r"NAME=\"OldPwd\" SIZE=\"12\" MAXLENGTH=\"12\" VALUE=\"([�-9]+)\""
                 password = re.findall(pattern, r.content)[0].replace('&', ';&')[1:] + ";"
                 print_success("Target password is : {}".format(password))
-        except Exception:
+        except requests.exceptions.RequestException:
             print_error("Unable to connect to target")

--- a/routersploit/modules/exploits/routers/mikrotik/winbox_auth_bypass_creds_disclosure.py
+++ b/routersploit/modules/exploits/routers/mikrotik/winbox_auth_bypass_creds_disclosure.py
@@ -118,7 +118,7 @@ class Exploit(TCPClient):
         for entry in entries:
             try:
                 user, pass_encrypted = self.extract_user_pass_from_entry(entry)
-            except Exception:
+            except (IndexError, ValueError):
                 continue
 
             pass_plain = self.decrypt_password(user, pass_encrypted)

--- a/routersploit/modules/exploits/routers/tplink/wdr842nd_wdr842n_configure_disclosure.py
+++ b/routersploit/modules/exploits/routers/tplink/wdr842nd_wdr842n_configure_disclosure.py
@@ -66,7 +66,7 @@ class Exploit(HTTPClient):
                     cPskSecret = item.split()[1]
                 if 'cUsrPIN' in item:
                     cUsrPIN = item.split()[1]
-            except Exception:
+            except (IndexError, AttributeError):
                 pass
         return authKey, cPskSecret, cUsrPIN
 

--- a/routersploit/modules/exploits/routers/zte/zxv10_rce.py
+++ b/routersploit/modules/exploits/routers/zte/zxv10_rce.py
@@ -72,7 +72,7 @@ class Exploit(HTTPClient):
                     res = res1 + res2
                     if res[0] != "</textarea>":
                         return res[0]
-        except Exception:
+        except (requests.exceptions.RequestException, IndexError):
             pass
 
         return ""
@@ -84,7 +84,7 @@ class Exploit(HTTPClient):
                 path="/template.gch",
                 session=self.session
             )
-        except Exception:
+        except requests.exceptions.RequestException:
             return
 
         # Check for Model Name
@@ -140,7 +140,7 @@ class Exploit(HTTPClient):
                    "404 Not Found" not in response.text and response.status_code != 404):
                     print_success("Successful authentication")
                     return True
-        except Exception:
+        except (requests.exceptions.RequestException, IndexError):
             pass
 
         return False


### PR DESCRIPTION
Found a bunch of bare `except Exception:` and `except:` across the codebase while debugging another issue. These make it really hard to figure out what went wrong when something breaks unexpectedly.

Changes:
- **FTP client**: `ftplib.error_temp`, `ftplib.error_perm`, `OSError` instead of bare Exception
- **Telnet client**: `socket.error`, `EOFError`, `OSError` for connection/auth operations
- **Shell**: `ValueError`, `TypeError`, `AttributeError` for setattr failures
- **BTLE device**: `BTLEException` from bluepy, `UnicodeDecodeError` for decode issues
- **Exploit modules**: `binascii.Error`/`ValueError` for base64, `requests.exceptions.RequestException` for HTTP, `IndexError`/`KeyError`/`json.JSONDecodeError` for parsing

Not sure if I got all the edge cases right but the specific types should cover the normal failure modes. Left the `except Exception` in `interpreter.py` since that one needs to catch everything for the module runner.

Closes #902