### PR TITLE
Add missing runtime dependencies and fix paramiko import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ requests==2.32.2
 paramiko
 pysnmp
 pycryptodome
+telnetlib3
+bluepy
+setuptools

--- a/routersploit/core/ssh/ssh_client.py
+++ b/routersploit/core/ssh/ssh_client.py
@@ -1,5 +1,9 @@
 import socket
 import paramiko
+try:
+    from paramiko import DSSKey
+except ImportError:
+    DSSKey = None
 import os
 import select
 import sys
@@ -82,8 +86,8 @@ class SSHCli:
         :return bool: True if login was successful, False otherwise
         """
 
-        if "DSA PRIVATE KEY" in priv_key:
-            priv_key = paramiko.DSSKey.from_private_key(io.StringIO(priv_key))
+        if DSSKey is not None and "DSA PRIVATE KEY" in priv_key:
+            priv_key = DSSKey.from_private_key(io.StringIO(priv_key))
         elif "RSA PRIVATE KEY" in priv_key:
             priv_key = paramiko.RSAKey.from_private_key(io.StringIO(priv_key))
         else:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
         "paramiko",
         "pysnmp",
         "pycryptodome",
+        "telnetlib3",
+        "bluepy",
+        "setuptools",
     ],
     extras_require={
         "tests": [


### PR DESCRIPTION
Spent way too long trying to figure out why `pip install routersploit` was broken on my machine. Turns out several runtime deps are missing from requirements.txt.

**Missing deps:**
- `telnetlib3` - needed at runtime as fallback for `telnetlib` (removed in Python 3.13). It was only in requirements-dev.txt but the actual code imports it in `telnet_client.py` and `shell.py`
- `bluepy` - the bluetooth BLE modules import it but it was never listed as a dependency
- `setuptools` - `setup.py` uses it for installation but it wasnt listed

**Paramiko fix:**
`paramiko.DSSKey` was removed in paramiko 3.x which causes an AttributeError when trying to use DSA keys for SSH auth. Wrapped the import in a try/except so it degrades gracefully on newer paramiko. DSA keys are deprecated anyway so this seems like the right approach.

Tested on Python 3.12 and 3.13, everything imports correctly now.

Closes #900 Closes #892 Closes #898